### PR TITLE
INJIVER-1224 & INJIVER-1225 | API Automation Enhancements

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/injiverify/utils/InjiVerifyUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/injiverify/utils/InjiVerifyUtil.java
@@ -55,6 +55,11 @@ public class InjiVerifyUtil extends AdminTestUtil {
 					InjiVerifyConfigManager.getproperty(InjiVerifyConstants.PRESENTATION_DEFINITION_ID));
 		}
 
+		if (jsonString.contains("$INJIVERIFYBASEURL$")) {
+			jsonString = replaceKeywordWithValue(jsonString, "$INJIVERIFYBASEURL$",
+					InjiVerifyConfigManager.getproperty(InjiVerifyConstants.INJI_VERIFY_BASE_URL));
+		}
+
 		return jsonString;
 
 	}

--- a/api-test/src/main/resources/injiverify/CreateNewVerificationRequest/CreateNewVerificationRequest.yml
+++ b/api-test/src/main/resources/injiverify/CreateNewVerificationRequest/CreateNewVerificationRequest.yml
@@ -14,7 +14,7 @@ CreateNewVerificationRequest:
       output: '{
     "responseType": "vp_token",
     "clientId": "client123",
-    "responseUri": "/vp-submission/direct-post",
+    "responseUri": "$INJIVERIFYBASEURL$/v1/verify/vp-submission/direct-post",
     "id": "$PRESENTATIONDEFINITIONID$"
 }'
 
@@ -33,7 +33,7 @@ CreateNewVerificationRequest:
       output: '{
     "responseType": "vp_token",
     "clientId": "client123",
-    "responseUri": "/vp-submission/direct-post",
+    "responseUri": "$INJIVERIFYBASEURL$/v1/verify/vp-submission/direct-post",
     "id": "$PRESENTATIONDEFINITIONID$"
 }'
 
@@ -52,7 +52,7 @@ CreateNewVerificationRequest:
       output: '{
     "responseType": "vp_token",
     "clientId": "ygygduDS",
-    "responseUri": "/vp-submission/direct-post",
+    "responseUri": "$INJIVERIFYBASEURL$/v1/verify/vp-submission/direct-post",
     "id": "$PRESENTATIONDEFINITIONID$"
 }'
 
@@ -71,7 +71,7 @@ CreateNewVerificationRequest:
       output: '{
     "responseType": "vp_token",
     "clientId": "client123",
-    "responseUri": "/vp-submission/direct-post",
+    "responseUri": "$INJIVERIFYBASEURL$/v1/verify/vp-submission/direct-post",
     "id": "dsAygyasa"
 }'
 
@@ -158,6 +158,6 @@ CreateNewVerificationRequest:
       output: '{
     "responseType": "vp_token",
     "clientId": "client123",
-    "responseUri": "/vp-submission/direct-post",
+    "responseUri": "$INJIVERIFYBASEURL$/v1/verify/vp-submission/direct-post",
     "id": "$PRESENTATIONDEFINITIONID$"
 }'

--- a/api-test/src/main/resources/injiverify/CreateNewVerificationRequestWithDID/CreateNewVerificationRequestWithDID.hbs
+++ b/api-test/src/main/resources/injiverify/CreateNewVerificationRequestWithDID/CreateNewVerificationRequestWithDID.hbs
@@ -1,0 +1,14 @@
+{
+  "clientId": "{{clientId}}",
+  "presentationDefinition": {
+    "id": "{{id}}",
+    "input_descriptors": [
+      {
+        "id": "wa_driver_license",
+        "name": "Washington State Business License",
+        "purpose": "We can only allow licensed Washington State business representatives into the WA Business Conference",
+        "constraints": {}
+      }
+    ]
+  }
+}

--- a/api-test/src/main/resources/injiverify/CreateNewVerificationRequestWithDID/CreateNewVerificationRequestWithDID.yml
+++ b/api-test/src/main/resources/injiverify/CreateNewVerificationRequestWithDID/CreateNewVerificationRequestWithDID.yml
@@ -1,0 +1,17 @@
+CreateNewVerificationRequestWithDID:
+  Injiverify_CreateNewVerificationRequest_DID_ClientId_Valid_Sid:
+      endPoint: /v1/verify/vp-request
+      description: Creating a new verification request with DID-based client id
+      uniqueIdentifier: TC_InjiVerify_CreateNewVerificationRequestWithDID_01
+      role: noauth
+      restMethod: post
+      checkOnlyStatusCodeInResponse: true
+      inputTemplate: injiverify/CreateNewVerificationRequestWithDID/CreateNewVerificationRequestWithDID
+      outputTemplate: injiverify/responseCode
+      input: '{
+      "clientId":"did:client123",
+      "id":"$PRESENTATIONDEFINITIONID$"
+      }'
+      output: '{
+      "responseCode": "201"
+}'

--- a/api-test/src/main/resources/injiverify/CreateNewVerificationRequestWithDID/CreateNewVerificationRequestWithDIDResult.hbs
+++ b/api-test/src/main/resources/injiverify/CreateNewVerificationRequestWithDID/CreateNewVerificationRequestWithDIDResult.hbs
@@ -1,0 +1,6 @@
+{
+  "transactionId": "{{transactionId}}",
+  "requestId": "{{requestId}}",
+  "requestUri": "{{requestUri}}",
+  "expiresAt": {{expiresAt}}
+}

--- a/api-test/testNgXmlFiles/injiverifySuite.xml
+++ b/api-test/testNgXmlFiles/injiverifySuite.xml
@@ -17,6 +17,15 @@
 				name="io.mosip.testrig.apirig.injiverify.testscripts.SimplePostForAutoGenId" />
 		</classes>
 	</test>
+	<test name="CreateNewVerificationRequestWithDID">
+		<parameter name="ymlFile"
+			value="injiverify/CreateNewVerificationRequestWithDID/CreateNewVerificationRequestWithDID.yml" />
+		<parameter name="idKeyName" value="transactionId,requestId,id" />
+		<classes>
+			<class
+				name="io.mosip.testrig.apirig.injiverify.testscripts.SimplePostForAutoGenId" />
+		</classes>
+	</test>
 	<test name="VpSubmission">
 		<parameter name="ymlFile"
 			value="injiverify/VpSubmission/VpSubmission.yml" />


### PR DESCRIPTION
This PR adds automation coverage for the following tasks:

- INJIVER-1224: Automated API tests for OpenID4VP: Authorization Request via request_uri for DID client id.
- INJIVER-1225: Automated API tests for DID-based client_id Scheme.

**Details:**
- Added/updated test cases in the API automation suite for both scenarios.
- Verified in dev-int-inji environment with mosipid/apitest-inji-verify:0.12.3.
- Adjusted validation for /vp-request endpoint to handle updated authorizationDetails.responseUri format (from relative path to full URL).