### PR TITLE
Revert "INJIVER 1464 saving selected credentials in session storage in verify UI "

### DIFF
--- a/verify-ui/src/components/Home/VerificationSection/VpVerification.tsx
+++ b/verify-ui/src/components/Home/VerificationSection/VpVerification.tsx
@@ -71,7 +71,7 @@ const DisplayActiveStep = () => {
                          }),
                );
                     // Clear persisted selection once we have fetched and processed VP result
-                    sessionStorage.removeItem(OVP_SESSION_SELECTED_CREDENTIALS_KEY);
+                    localStorage.removeItem(OVP_SESSION_SELECTED_CREDENTIALS_KEY);
                     dispatch(verificationSubmissionComplete({ verificationResult: processedResults }));
               } catch (error: any) {
                 handleOnError(error);
@@ -116,12 +116,12 @@ const DisplayActiveStep = () => {
 
   useEffect(() => {
     if (originalSelectedCredentials.length === 0) {
-      sessionStorage.removeItem(OVP_SESSION_SELECTED_CREDENTIALS_KEY);
+      localStorage.removeItem(OVP_SESSION_SELECTED_CREDENTIALS_KEY);
       return;
     }
 
     if (activeScreen === 3 || unverifiedCredentials.length > 0) {
-      sessionStorage.setItem(
+      localStorage.setItem(
         OVP_SESSION_SELECTED_CREDENTIALS_KEY,
         JSON.stringify(originalSelectedCredentials)
       );

--- a/verify-ui/src/redux/features/verify/vpVerificationState.ts
+++ b/verify-ui/src/redux/features/verify/vpVerificationState.ts
@@ -21,7 +21,7 @@ const hasValidCredentialStructure = (item: unknown): item is claim => {
 
 const restoreCredentialsFromSession = (): claim[] => {
   try {
-    const saved = sessionStorage.getItem(OVP_SESSION_SELECTED_CREDENTIALS_KEY);
+    const saved = localStorage.getItem(OVP_SESSION_SELECTED_CREDENTIALS_KEY);
     if (!saved) return DEFAULT_CREDENTIALS();
     const parsed: unknown = JSON.parse(saved);
     if (!Array.isArray(parsed) || parsed.length === 0) return DEFAULT_CREDENTIALS();
@@ -166,7 +166,7 @@ const vpVerificationState = createSlice({
     resetVpRequest: (state) => {
       const prevSdkKey = state.sdkInstanceKey;
       try {
-        sessionStorage.removeItem(OVP_SESSION_SELECTED_CREDENTIALS_KEY);
+        localStorage.removeItem(OVP_SESSION_SELECTED_CREDENTIALS_KEY);
       } catch {
         // Ignore storage errors; state reset must still proceed
       }


### PR DESCRIPTION
Reverts inji/inji-verify#1263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced credential persistence to maintain selections across browser sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->