### PR TITLE
INJIVER-1567 Removed redirect_uri from OnlineSharing VC flow

### DIFF
--- a/inji-verify-sdk/package-lock.json
+++ b/inji-verify-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@injistack/react-inji-verify-sdk",
-  "version": "0.18.0-beta.17",
+  "version": "0.18.0-beta.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@injistack/react-inji-verify-sdk",
-      "version": "0.18.0-beta.17",
+      "version": "0.18.0-beta.18",
       "license": "MPL-2.0",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",

--- a/inji-verify-sdk/package.json
+++ b/inji-verify-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@injistack/react-inji-verify-sdk",
-  "version": "0.18.0-beta.17",
+  "version": "0.18.0-beta.18",
   "description": "A react component library to perform Inji verify tasks, such as OpenId4VP sharing, Reading VC QR codes",
   "sideEffects": [
     "*.css"

--- a/inji-verify-sdk/src/components/qrcode-verification/QRCodeVerification.tsx
+++ b/inji-verify-sdk/src/components/qrcode-verification/QRCodeVerification.tsx
@@ -398,7 +398,6 @@ const QRCodeVerification: React.FC<QRCodeVerificationProps> = ({
     const url = new URL(baseRedirectUrl);
     url.hash = "";
     url.searchParams.set("client_id", clientId);
-    url.searchParams.set("redirect_uri", redirectUri);
     url.searchParams.set("state", state);
     url.searchParams.set("response_mode", "direct_post");
     url.searchParams.set("response_uri", responseUri);
@@ -419,8 +418,7 @@ const QRCodeVerification: React.FC<QRCodeVerificationProps> = ({
           throw new Error("Failed to extract redirect URL from QR data");
 
         if (!isVPSubmissionSupported) {
-          const encodedOrigin = encodeURIComponent(window.location.origin);
-          window.location.href = `${redirectUrl}&client_id=${clientId}&redirect_uri=${encodedOrigin}%2F#`;
+          window.location.href = `${redirectUrl}&client_id=${clientId}%2F#`;
           return;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Version bumped to 0.18.0-beta.18

* **Bug Fixes**
  * Redirect operations no longer transmit the redirect_uri parameter in requests to external redirect endpoints. All other request parameters remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->