### PR TITLE
MOSIP-44709: Fixed HealthCheck module mapping by using normalized module name instead of prefixed identifier.

### DIFF
--- a/api-test/src/main/java/io/inji/testrig/apirig/injiverify/testrunner/InjiTestRunner.java
+++ b/api-test/src/main/java/io/inji/testrig/apirig/injiverify/testrunner/InjiTestRunner.java
@@ -79,7 +79,7 @@ public class InjiTestRunner {
 			}
 
 			HealthChecker healthcheck = new HealthChecker();
-			healthcheck.setCurrentRunningModule(BaseTestCase.currentModule);
+			healthcheck.setCurrentRunningModule(GlobalConstants.INJIVERIFY);
 			Thread trigger = new Thread(healthcheck);
 			trigger.start();
 


### PR DESCRIPTION
Fixes HealthCheck module mismatch by replacing the prefixed module name (BaseTestCase.currentModule) with a normalized value (GlobalConstants.INJIVERIFY), ensuring correct mapping with healthCheckEndpoint.properties and proper endpoint filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected health checker module tracking to use the appropriate module identifier during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->