### PR TITLE
INJIVER-1603-verify-service-sonar-coverage-fix

### DIFF
--- a/verify-service/src/test/java/io/inji/verify/controller/VPResultControllerTest.java
+++ b/verify-service/src/test/java/io/inji/verify/controller/VPResultControllerTest.java
@@ -110,7 +110,7 @@ public class VPResultControllerTest {
         when(verifiablePresentationSubmissionService.getVPResult(requestIds, transactionId)).thenThrow(new VPWithoutProofException());
 
         mockMvc.perform(get("/vp-result/{transactionId}", transactionId)
-                        .contentType(MediaType.APPLICATION_JSON))
+                .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().string(objectMapper.writeValueAsString(new ErrorDto(ErrorCode.VP_WITHOUT_PROOF))));
 
@@ -199,7 +199,7 @@ public class VPResultControllerTest {
     }
 
     @Test
-    void testGetVPResultV2_NotFound_WhenRequestIdsEmpty() throws Exception {
+    void testGetVPResultV2_shouldReturnNotFound_WhenRequestIdsEmpty() throws Exception {
         String transactionId = "txn404";
 
         VerificationRequestDto request = new VerificationRequestDto();
@@ -247,7 +247,7 @@ public class VPResultControllerTest {
     }
 
     @Test
-    void testGetVPSessionResults_MissingCookie() throws Exception {
+    void testGetVPSessionResults_shouldReturnUnauthorized_whenMissingCookie() throws Exception {
 
         mockMvc.perform(post("/vp-session-results")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -256,7 +256,7 @@ public class VPResultControllerTest {
     }
 
     @Test
-    void testGetVPSessionResults_EmptyCookie() throws Exception {
+    void testGetVPSessionResults_shouldReturnUnauthorized_whenEmptyCookie() throws Exception {
 
         mockMvc.perform(post("/vp-session-results")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -266,7 +266,7 @@ public class VPResultControllerTest {
     }
 
     @Test
-    void testGetVPSessionResults_RequestIdsEmpty() throws Exception {
+    void testGetVPSessionResults_shouldReturn_isNotFound_whenRequestIdsEmpty() throws Exception {
         String transactionId = "txn404";
         String encodedCookie = Base64.getEncoder().encodeToString(transactionId.getBytes());
 
@@ -301,7 +301,7 @@ public class VPResultControllerTest {
     }
 
     @Test
-    void testGetVPResult_ResponseCodeException() throws Exception {
+    void testGetVPResult_shouldReturnBadRequest_whenResponseCodeException() throws Exception {
         String transactionId = "tx_resp_code";
         List<String> requestIds = List.of("req123");
 

--- a/verify-service/src/test/java/io/inji/verify/controller/VPResultControllerTest.java
+++ b/verify-service/src/test/java/io/inji/verify/controller/VPResultControllerTest.java
@@ -1,18 +1,21 @@
 package io.inji.verify.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.inji.verify.dto.VerificationSessionRequestDto;
+import java.util.Base64;
+import static io.inji.verify.shared.Constants.COOKIE_NAME;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import io.inji.verify.dto.core.ErrorDto;
+import io.inji.verify.dto.result.VPVerificationResultDto;
+import io.inji.verify.dto.result.VerificationRequestDto;
 import io.inji.verify.dto.submission.VPTokenResultDto;
 import io.inji.verify.enums.ErrorCode;
 import io.inji.verify.enums.VPResultStatus;
-import io.inji.verify.exception.VPSubmissionNotFoundException;
-import io.inji.verify.exception.VPWithoutProofException;
-import io.inji.verify.exception.TokenMatchingFailedException;
-import io.inji.verify.exception.VPSubmissionWalletError;
-import io.inji.verify.exception.InvalidVpTokenException;
+import io.inji.verify.exception.*;
 import io.inji.verify.services.VCSubmissionService;
 import io.inji.verify.services.VerifiablePresentationRequestService;
 import io.inji.verify.services.VerifiablePresentationSubmissionService;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -23,8 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 public class VPResultControllerTest {
 
@@ -108,7 +110,7 @@ public class VPResultControllerTest {
         when(verifiablePresentationSubmissionService.getVPResult(requestIds, transactionId)).thenThrow(new VPWithoutProofException());
 
         mockMvc.perform(get("/vp-result/{transactionId}", transactionId)
-                .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().string(objectMapper.writeValueAsString(new ErrorDto(ErrorCode.VP_WITHOUT_PROOF))));
 
@@ -171,5 +173,172 @@ public class VPResultControllerTest {
                 .andExpect(content().string(objectMapper.writeValueAsString(new ErrorDto(ErrorCode.INVALID_VP_TOKEN))));
 
         verify(verifiablePresentationSubmissionService, times(1)).getVPResult(requestIds, transactionId);
+    }
+
+    @Test
+    void testGetVPResultV2_Success() throws Exception {
+        String transactionId = "txn123";
+
+        String requestJson = "{}"; // or add fields if required
+
+        List<String> requestIds = List.of("req1");
+
+        when(verifiablePresentationRequestService.getLatestRequestIdFor(transactionId))
+                .thenReturn(requestIds);
+
+        when(verifiablePresentationSubmissionService.getVPResultV2(
+                any(),
+                eq(requestIds),
+                eq(transactionId)
+        )).thenReturn(new VPVerificationResultDto());
+
+        mockMvc.perform(post("/v2/vp-results/{transactionId}", transactionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testGetVPResultV2_NotFound_WhenRequestIdsEmpty() throws Exception {
+        String transactionId = "txn404";
+
+        VerificationRequestDto request = new VerificationRequestDto();
+
+        when(verifiablePresentationRequestService.getLatestRequestIdFor(transactionId))
+                .thenReturn(List.of());
+
+        mockMvc.perform(post("/v2/vp-results/{transactionId}", transactionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string(
+                        objectMapper.writeValueAsString(new ErrorDto(ErrorCode.INVALID_TRANSACTION_ID))
+                ));
+
+        verify(verifiablePresentationSubmissionService, never())
+                .getVPResultV2(any(), any(), any());
+    }
+
+    @Test
+    void testGetVPSessionResults_Success() throws Exception {
+        String transactionId = "txn123";
+        String encodedCookie = Base64.getEncoder().encodeToString(transactionId.getBytes());
+
+        VerificationSessionRequestDto request = new VerificationSessionRequestDto();
+        List<String> requestIds = List.of("req1");
+
+        when(verifiablePresentationRequestService.getLatestRequestIdFor(transactionId))
+                .thenReturn(requestIds);
+
+        when(verifiablePresentationSubmissionService.getVPSessionResults(
+                any(),
+                eq(requestIds),
+                eq(transactionId)
+        )).thenReturn(new VPVerificationResultDto());
+
+        mockMvc.perform(post("/vp-session-results")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                        .cookie(new Cookie(COOKIE_NAME, encodedCookie)))
+                .andExpect(status().isOk());
+
+        verify(verifiablePresentationSubmissionService, times(1))
+                .getVPSessionResults(any(), eq(requestIds), eq(transactionId));
+    }
+
+    @Test
+    void testGetVPSessionResults_MissingCookie() throws Exception {
+
+        mockMvc.perform(post("/vp-session-results")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testGetVPSessionResults_EmptyCookie() throws Exception {
+
+        mockMvc.perform(post("/vp-session-results")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                        .cookie(new Cookie(COOKIE_NAME, "")))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testGetVPSessionResults_RequestIdsEmpty() throws Exception {
+        String transactionId = "txn404";
+        String encodedCookie = Base64.getEncoder().encodeToString(transactionId.getBytes());
+
+        when(verifiablePresentationRequestService.getLatestRequestIdFor(transactionId))
+                .thenReturn(List.of());
+
+        mockMvc.perform(post("/vp-session-results")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                        .cookie(new Cookie(COOKIE_NAME, encodedCookie)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testGetVPSessionResults_CookieCleanup() throws Exception {
+        String transactionId = "txn123";
+        String encodedCookie = Base64.getEncoder().encodeToString(transactionId.getBytes());
+
+        when(verifiablePresentationRequestService.getLatestRequestIdFor(transactionId))
+                .thenReturn(List.of("req1"));
+
+        when(verifiablePresentationSubmissionService.getVPSessionResults(
+                any(), any(), any()))
+                .thenReturn(new VPVerificationResultDto());
+
+        mockMvc.perform(post("/vp-session-results")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                        .cookie(new Cookie(COOKIE_NAME, encodedCookie)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge(COOKIE_NAME, 0)); // cookie cleared
+    }
+
+    @Test
+    void testGetVPResult_ResponseCodeException() throws Exception {
+        String transactionId = "tx_resp_code";
+        List<String> requestIds = List.of("req123");
+
+        ErrorCode errorCode = ErrorCode.INVALID_TRANSACTION_ID; // use any valid enum
+
+        when(verifiablePresentationRequestService.getLatestRequestIdFor(transactionId))
+                .thenReturn(requestIds);
+
+        when(verifiablePresentationSubmissionService.getVPResult(requestIds, transactionId))
+                .thenThrow(new ResponseCodeException(errorCode));
+
+        mockMvc.perform(get("/vp-result/{transactionId}", transactionId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(
+                        objectMapper.writeValueAsString(
+                                new ErrorDto(errorCode.name(), errorCode.getErrorMessage())
+                        )
+                ));
+
+        verify(verifiablePresentationSubmissionService, times(1))
+                .getVPResult(requestIds, transactionId);
+    }
+
+    @Test
+    void testGetVPSessionResults_MalformedCookieException() throws Exception {
+        String invalidCookie = "invalid_base64@@@"; // will fail decoding
+
+        mockMvc.perform(post("/vp-session-results")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                        .cookie(new Cookie(COOKIE_NAME, invalidCookie)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(
+                        objectMapper.writeValueAsString(
+                                new ErrorDto(ErrorCode.MALFORMED_COOKIE)
+                        )
+                ));
     }
 }

--- a/verify-service/src/test/java/io/inji/verify/controller/VPResultControllerTest.java
+++ b/verify-service/src/test/java/io/inji/verify/controller/VPResultControllerTest.java
@@ -11,7 +11,12 @@ import io.inji.verify.dto.result.VerificationRequestDto;
 import io.inji.verify.dto.submission.VPTokenResultDto;
 import io.inji.verify.enums.ErrorCode;
 import io.inji.verify.enums.VPResultStatus;
-import io.inji.verify.exception.*;
+import io.inji.verify.exception.InvalidVpTokenException;
+import io.inji.verify.exception.TokenMatchingFailedException;
+import io.inji.verify.exception.VPSubmissionNotFoundException;
+import io.inji.verify.exception.VPSubmissionWalletError;
+import io.inji.verify.exception.VPWithoutProofException;
+import io.inji.verify.exception.ResponseCodeException;
 import io.inji.verify.services.VCSubmissionService;
 import io.inji.verify.services.VerifiablePresentationRequestService;
 import io.inji.verify.services.VerifiablePresentationSubmissionService;
@@ -26,7 +31,9 @@ import java.util.ArrayList;
 import java.util.List;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 
 
 public class VPResultControllerTest {

--- a/verify-service/src/test/java/io/inji/verify/controller/VPResultControllerTest.java
+++ b/verify-service/src/test/java/io/inji/verify/controller/VPResultControllerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+
 public class VPResultControllerTest {
 
     private final VerifiablePresentationRequestService verifiablePresentationRequestService = Mockito.mock(VerifiablePresentationRequestService.class);

--- a/verify-service/src/test/java/io/inji/verify/utils/UtilsTest.java
+++ b/verify-service/src/test/java/io/inji/verify/utils/UtilsTest.java
@@ -1,8 +1,11 @@
 package io.inji.verify.utils;
 
 import com.upokecenter.cbor.CBORObject;
+import io.inji.verify.dto.verification.StatusCheckDto;
 import io.inji.verify.exception.InvalidCredentialException;
+import io.mosip.pixelpass.PixelPass;
 import io.mosip.vercred.vcverifier.constants.CredentialFormat;
+import io.mosip.vercred.vcverifier.data.CredentialStatusResult;
 import org.junit.jupiter.api.Test;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -83,23 +86,23 @@ public class UtilsTest {
 
     @Test
     void testExcludeMetaClaimsCoverage() throws Exception {
-            Method method = Utils.class.getDeclaredMethod("excludeMetaClaims", List.class, Map.class);
-            method.setAccessible(true);
+        Method method = Utils.class.getDeclaredMethod("excludeMetaClaims", List.class, Map.class);
+        method.setAccessible(true);
 
-            Map<String, Object> claims = new HashMap<>();
-            claims.put("stay", "safe");
-            claims.put("remove", "meta");
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("stay", "safe");
+        claims.put("remove", "meta");
 
-            assertDoesNotThrow(() -> method.invoke(null, null, claims));
+        assertDoesNotThrow(() -> method.invoke(null, null, claims));
 
-            List<String> metaWithNull = Collections.singletonList(null);
-            assertDoesNotThrow(() -> method.invoke(null, metaWithNull, claims));
+        List<String> metaWithNull = Collections.singletonList(null);
+        assertDoesNotThrow(() -> method.invoke(null, metaWithNull, claims));
 
-            List<String> validMeta = List.of("  remove  ");
-            method.invoke(null, validMeta, claims);
+        List<String> validMeta = List.of("  remove  ");
+        method.invoke(null, validMeta, claims);
 
-            assertFalse(claims.containsKey("remove"), "Claim should be removed");
-            assertEquals(1, claims.size());
+        assertFalse(claims.containsKey("remove"), "Claim should be removed");
+        assertEquals(1, claims.size());
 
     }
 
@@ -165,5 +168,104 @@ public class UtilsTest {
 
         assertNotNull(result);
         assertEquals("123", result.get(CBORObject.FromObject("sub")).AsString());
+    }
+
+    @Test
+    void populateStatusCheckDtoList_shouldReturnEmptyList_whenInputIsNull() {
+        List<StatusCheckDto> result = Utils.populateStatusCheckDtoList(null);
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void populateStatusCheckDtoList_shouldHandleNullCredentialStatusResult() {
+        Map<String, CredentialStatusResult> map = new HashMap<>();
+        map.put("revocation", null);
+
+        List<StatusCheckDto> result = Utils.populateStatusCheckDtoList(map);
+
+        assertEquals(1, result.size());
+
+        StatusCheckDto dto = result.get(0);
+        assertEquals("revocation", dto.getPurpose());
+        assertFalse(dto.isValid());
+        assertNotNull(dto.getError());
+        assertEquals("NULL_STATUS_RESULT", dto.getError().getErrorCode());
+        assertEquals("Credential status result was null.", dto.getError().getErrorMessage());
+    }
+
+    @Test
+    void populateStatusCheckDtoList_shouldHandleValidResult_withoutError() {
+        CredentialStatusResult mockResult = mock(CredentialStatusResult.class);
+        when(mockResult.isValid()).thenReturn(true);
+        when(mockResult.getError()).thenReturn(null);
+
+        Map<String, CredentialStatusResult> map = Map.of("revocation", mockResult);
+
+        List<StatusCheckDto> result = Utils.populateStatusCheckDtoList(map);
+
+        assertEquals(1, result.size());
+
+        StatusCheckDto dto = result.get(0);
+        assertEquals("revocation", dto.getPurpose());
+        assertTrue(dto.isValid());
+        assertNull(dto.getError());
+    }
+
+
+    @Test
+    void extractClaims_shouldCallLdpBranch() {
+        String jsonCredential = "{ \"credentialSubject\": { \"name\": \"John\" } }";
+
+        Map<String, Object> result = Utils.extractClaims(
+                jsonCredential,
+                CredentialFormat.LDP_VC,
+                null,
+                null
+        );
+
+        assertNotNull(result);
+        assertEquals("John", result.get("name"));
+    }
+
+    @Test
+    void extractClaims_shouldCallCwtBranch() {
+        String credential = "dummyCwt";
+        List<String> metaClaims = List.of("meta");
+
+        Map<String, Object> expected = Map.of("id", "123");
+
+        PixelPass pixelPass = mock(PixelPass.class);
+
+        try (var mockedUtils = mockStatic(Utils.class, CALLS_REAL_METHODS)) {
+
+            mockedUtils.when(() ->
+                    Utils.extractCwtClaims(credential, pixelPass, metaClaims)
+            ).thenReturn(expected);
+
+            Map<String, Object> result = Utils.extractClaims(
+                    credential,
+                    CredentialFormat.CWT_VC,
+                    metaClaims,
+                    pixelPass
+            );
+
+            assertEquals(expected, result);
+        }
+    }
+
+    @Test
+    void extractClaims_shouldReturnLdpClaims() {
+        String json = "{ \"credentialSubject\": { \"name\": \"John\" } }";
+
+        Map<String, Object> result = Utils.extractClaims(
+                json,
+                CredentialFormat.LDP_VC,
+                null,
+                null
+        );
+
+        assertNotNull(result);
+        assertEquals("John", result.get("name"));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added POST /v2/vp-results/{transactionId} tests: success, not-found, and skipping downstream calls when IDs are missing; maps service errors to 400 with appropriate error codes.
  * Added POST /vp-session-results cookie-flow tests: Base64 decoding, successful flow with decoded IDs, missing/empty cookie -> 401, malformed cookie -> 400 (MALFORMED_COOKIE), not-found for empty decoded IDs, and cookie cleanup verification.
  * Extended utility tests for null input handling, status-check mapping, and claims extraction across credential formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->