### PR TITLE
[INJIVER-1627] fix:prevent QR scanner startup on wallet redirect response_code

### DIFF
--- a/inji-verify-sdk/package-lock.json
+++ b/inji-verify-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@injistack/react-inji-verify-sdk",
-  "version": "0.19.0-beta.1",
+  "version": "0.19.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@injistack/react-inji-verify-sdk",
-      "version": "0.19.0-beta.1",
+      "version": "0.19.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",

--- a/inji-verify-sdk/package.json
+++ b/inji-verify-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@injistack/react-inji-verify-sdk",
-  "version": "0.19.0-beta.1",
+  "version": "0.19.0-beta.2",
   "description": "A react component library to perform Inji verify tasks, such as OpenId4VP sharing, Reading VC QR codes",
   "sideEffects": [
     "*.css"

--- a/inji-verify-sdk/src/components/qrcode-verification/QRCodeVerification.tsx
+++ b/inji-verify-sdk/src/components/qrcode-verification/QRCodeVerification.tsx
@@ -644,13 +644,18 @@ const QRCodeVerification: React.FC<QRCodeVerificationProps> = ({
         }
     };
 
+    const hash = window.location.hash;
+    const params = new URLSearchParams(hash.substring(1));
+    const responseCode = params.get("response_code");
+
   const startScanning =
     Boolean(scannerActive) &&
     isEnableScan &&
     (hasTrigger ? activeFlow === "scan" || activeFlow === "inline" : true) &&
     !isUploading &&
     !isScanning &&
-    !scanSessionCompletedRef.current;
+    !scanSessionCompletedRef.current &&
+    !Boolean(responseCode);
 
   const startVideoStreamRef = useRef(startVideoStream);
   startVideoStreamRef.current = startVideoStream;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.19.0-beta.2

* **Bug Fixes**
  * Fixed QR code scanning to prevent unnecessary camera activation when a response code is already available in the current session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->