### PR TITLE
[INJIVER-1758] change client metadata VP_FORMATS to VP_FORMATS_SUPPORTED

### DIFF
--- a/inji-verify-sdk/package-lock.json
+++ b/inji-verify-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@injistack/react-inji-verify-sdk",
-  "version": "0.19.0-beta.2",
+  "version": "0.19.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@injistack/react-inji-verify-sdk",
-      "version": "0.19.0-beta.2",
+      "version": "0.19.0-beta.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",

--- a/inji-verify-sdk/package-lock.json
+++ b/inji-verify-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@injistack/react-inji-verify-sdk",
-  "version": "0.19.0-beta.3",
+  "version": "0.19.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@injistack/react-inji-verify-sdk",
-      "version": "0.19.0-beta.3",
+      "version": "0.19.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",

--- a/inji-verify-sdk/package.json
+++ b/inji-verify-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@injistack/react-inji-verify-sdk",
-  "version": "0.19.0-beta.2",
+  "version": "0.19.0-beta.4",
   "description": "A react component library to perform Inji verify tasks, such as OpenId4VP sharing, Reading VC QR codes",
   "sideEffects": [
     "*.css"

--- a/inji-verify-sdk/package.json
+++ b/inji-verify-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@injistack/react-inji-verify-sdk",
-  "version": "0.19.0-beta.3",
+  "version": "0.19.0-beta.2",
   "description": "A react component library to perform Inji verify tasks, such as OpenId4VP sharing, Reading VC QR codes",
   "sideEffects": [
     "*.css"

--- a/inji-verify-sdk/src/components/openid4vp-verification/OpenID4VPVerification.tsx
+++ b/inji-verify-sdk/src/components/openid4vp-verification/OpenID4VPVerification.tsx
@@ -73,13 +73,13 @@ const OpenID4VPVerification: React.FC<OpenID4VPVerificationProps> = ({
         ],
       },
       "dc+sd-jwt": {
-        "sd-jwt_alg_values": ["ES256", "ES384"],
-        "kb-jwt_alg_values": ["ES256", "ES384"]
+        "sd-jwt_alg_values": ["RS256", "ES256", "ES256K", "EdDSA"],
+        "kb-jwt_alg_values": ["RS256", "ES256", "ES256K", "EdDSA"],
       },
       "vc+sd-jwt": {
-        "sd-jwt_alg_values": ["ES256", "ES384"],
-        "kb-jwt_alg_values": ["ES256", "ES384"]
-      }
+        "sd-jwt_alg_values": ["RS256", "ES256", "ES256K", "EdDSA"],
+        "kb-jwt_alg_values": ["RS256", "ES256", "ES256K", "EdDSA"],
+      },
     }),
     []
   );

--- a/inji-verify-sdk/src/components/openid4vp-verification/OpenID4VPVerification.tsx
+++ b/inji-verify-sdk/src/components/openid4vp-verification/OpenID4VPVerification.tsx
@@ -63,7 +63,7 @@ const OpenID4VPVerification: React.FC<OpenID4VPVerificationProps> = ({
 
   const DEFAULT_PROTOCOL = "openid4vp://";
 
-  const VPFormat = useMemo(
+  const VPFormatsSupported = useMemo(
     () => ({
       ldp_vp: {
         proof_type: [
@@ -125,7 +125,7 @@ const OpenID4VPVerification: React.FC<OpenID4VPVerificationProps> = ({
           "client_metadata",
           JSON.stringify({
             client_name: clientId,
-            vp_formats: VPFormat,
+            vp_formats_supported: VPFormatsSupported,
           })
         );
       }

--- a/inji-verify-sdk/src/components/openid4vp-verification/OpenID4VPVerification.tsx
+++ b/inji-verify-sdk/src/components/openid4vp-verification/OpenID4VPVerification.tsx
@@ -72,10 +72,14 @@ const OpenID4VPVerification: React.FC<OpenID4VPVerificationProps> = ({
           "RsaSignature2018",
         ],
       },
-      "vc+sd-jwt": {
-        "sd-jwt_alg_values": ["RS256", "ES256", "ES256K", "EdDSA"],
-        "kb-jwt_alg_values": ["RS256", "ES256", "ES256K", "EdDSA"],
+      "dc+sd-jwt": {
+        "sd-jwt_alg_values": ["ES256", "ES384"],
+        "kb-jwt_alg_values": ["ES256", "ES384"]
       },
+      "vc+sd-jwt": {
+        "sd-jwt_alg_values": ["ES256", "ES384"],
+        "kb-jwt_alg_values": ["ES256", "ES384"]
+      }
     }),
     []
   );

--- a/verify-service/src/main/java/io/inji/verify/dto/client/ClientMetadataDto.java
+++ b/verify-service/src/main/java/io/inji/verify/dto/client/ClientMetadataDto.java
@@ -12,7 +12,7 @@ public class ClientMetadataDto {
     @SerializedName("client_name")
     String clientName;
 
-    @JsonProperty("vp_formats")
-    @SerializedName("vp_formats")
-    VpFormats vpFormats;
+    @JsonProperty("vp_formats_supported")
+    @SerializedName("vp_formats_supported")
+    VpFormatsSupported vpFormatsSupported;
 }

--- a/verify-service/src/main/java/io/inji/verify/dto/client/VpFormatsSupported.java
+++ b/verify-service/src/main/java/io/inji/verify/dto/client/VpFormatsSupported.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public class VpFormats {
+public class VpFormatsSupported {
     @JsonProperty("ldp_vp")
     @SerializedName("ldp_vp")
     private LdpVp ldpVp;

--- a/verify-service/src/main/java/io/inji/verify/dto/client/VpFormatsSupported.java
+++ b/verify-service/src/main/java/io/inji/verify/dto/client/VpFormatsSupported.java
@@ -15,4 +15,8 @@ public class VpFormatsSupported {
     @JsonProperty("vc+sd-jwt")
     @SerializedName("vc+sd-jwt")
     private SdJwt sdJwt;
+
+    @JsonProperty("dc+sd-jwt")
+    @SerializedName("dc+sd-jwt")
+    private SdJwt dcSdJwt;
 }

--- a/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationRequestServiceImpl.java
+++ b/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationRequestServiceImpl.java
@@ -48,7 +48,7 @@ import java.util.NoSuchElementException;
 import java.util.Date;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
-import static io.inji.verify.shared.Constants.VP_FORMATS;
+import static io.inji.verify.shared.Constants.VP_FORMATS_SUPPORTED;
 
 @Service
 @Slf4j
@@ -209,7 +209,7 @@ public class VerifiablePresentationRequestServiceImpl implements VerifiablePrese
                     .claim("nonce", authorizationRequest.getNonce())
                     .claim("state", state)
                     .claim("response_uri", authorizationRequest.getResponseUri())
-                    .claim("client_metadata", new ClientMetadataDto(verifierDid,VP_FORMATS))
+                    .claim("client_metadata", new ClientMetadataDto(verifierDid,VP_FORMATS_SUPPORTED))
                     .build();
             if (authorizationRequest.getPresentationDefinitionUri() != null) {
                 claimsSet = new JWTClaimsSet.Builder(claimsSet)

--- a/verify-service/src/main/java/io/inji/verify/shared/Constants.java
+++ b/verify-service/src/main/java/io/inji/verify/shared/Constants.java
@@ -1,7 +1,7 @@
 package io.inji.verify.shared;
 
 import io.inji.verify.dto.client.LdpVp;
-import io.inji.verify.dto.client.VpFormats;
+import io.inji.verify.dto.client.VpFormatsSupported;
 import io.inji.verify.dto.client.SdJwt;
 
 import java.util.Arrays;

--- a/verify-service/src/main/java/io/inji/verify/shared/Constants.java
+++ b/verify-service/src/main/java/io/inji/verify/shared/Constants.java
@@ -33,7 +33,7 @@ public final class Constants {
     public static final String RSA_SIGNATURE_2018 = "RsaSignature2018";
     public static final String ED25519_SIGNATURE_2018 = "Ed25519Signature2018";
     public static final String ED25519_SIGNATURE_2020 = "Ed25519Signature2020";
-    public static final VpFormats VP_FORMATS = new VpFormats(new LdpVp(Arrays.asList(
+    public static final VpFormatsSupported VP_FORMATS_SUPPORTED = new VpFormatsSupported(new LdpVp(Arrays.asList(
             ED25519_SIGNATURE_2018,
             ED25519_SIGNATURE_2020,
             RSA_SIGNATURE_2018

--- a/verify-service/src/main/java/io/inji/verify/shared/Constants.java
+++ b/verify-service/src/main/java/io/inji/verify/shared/Constants.java
@@ -38,6 +38,8 @@ public final class Constants {
             ED25519_SIGNATURE_2020,
             RSA_SIGNATURE_2018
     )), new SdJwt(SD_JWT_SUPPORTED_ALGORITHMS,
+            SD_JWT_SUPPORTED_ALGORITHMS), 
+        new SdJwt(SD_JWT_SUPPORTED_ALGORITHMS,
             SD_JWT_SUPPORTED_ALGORITHMS));
 
     // JSON KEYS

--- a/verify-service/src/test/java/io/inji/verify/dto/client/VpFormatsTest.java
+++ b/verify-service/src/test/java/io/inji/verify/dto/client/VpFormatsTest.java
@@ -15,7 +15,7 @@ public class VpFormatsTest {
         List<String> proofTypes = Arrays.asList("LdProof", "JsonWebSignature2020");
         LdpVp ldpVp = new LdpVp(proofTypes);
 
-        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(ldpVp,null);
+        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(ldpVp,null,null);
 
         assertNotNull(vpFormatsSupported.getLdpVp(), "The LdpVp object should not be null.");
         assertEquals(ldpVp, vpFormatsSupported.getLdpVp(), "The LdpVp object should match the one set in the constructor.");
@@ -29,7 +29,7 @@ public class VpFormatsTest {
 
     @Test
     public void testVpFormats_WithNullLdpVp() {
-        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(null,null);
+        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(null,null,null);
 
         assertNull(vpFormatsSupported.getLdpVp(), "The LdpVp object should be null when initialized with null.");
     }
@@ -39,7 +39,7 @@ public class VpFormatsTest {
         List<String> proofTypes = Arrays.asList();
         LdpVp ldpVp = new LdpVp(proofTypes);
 
-        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(ldpVp,null);
+        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(ldpVp,null,null);
 
         assertNotNull(vpFormatsSupported.getLdpVp(), "The LdpVp object should not be null.");
         assertEquals(ldpVp, vpFormatsSupported.getLdpVp(), "The LdpVp object should match the one set in the constructor.");
@@ -55,7 +55,7 @@ public class VpFormatsTest {
 
         SdJwt sdJwt = new SdJwt(algs, proofTypes);
 
-        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(null, sdJwt);
+        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(null, sdJwt, null);
 
         assertNotNull(vpFormatsSupported.getSdJwt(), "The SdJwt object should not be null.");
         assertEquals(sdJwt, vpFormatsSupported.getSdJwt(), "The SdJwt object should match the one set in the constructor.");

--- a/verify-service/src/test/java/io/inji/verify/dto/client/VpFormatsTest.java
+++ b/verify-service/src/test/java/io/inji/verify/dto/client/VpFormatsTest.java
@@ -15,12 +15,12 @@ public class VpFormatsTest {
         List<String> proofTypes = Arrays.asList("LdProof", "JsonWebSignature2020");
         LdpVp ldpVp = new LdpVp(proofTypes);
 
-        VpFormats vpFormats = new VpFormats(ldpVp,null);
+        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(ldpVp,null);
 
-        assertNotNull(vpFormats.getLdpVp(), "The LdpVp object should not be null.");
-        assertEquals(ldpVp, vpFormats.getLdpVp(), "The LdpVp object should match the one set in the constructor.");
+        assertNotNull(vpFormatsSupported.getLdpVp(), "The LdpVp object should not be null.");
+        assertEquals(ldpVp, vpFormatsSupported.getLdpVp(), "The LdpVp object should match the one set in the constructor.");
 
-        List<String> retrievedProofTypes = vpFormats.getLdpVp().getProofType();
+        List<String> retrievedProofTypes = vpFormatsSupported.getLdpVp().getProofType();
         assertNotNull(retrievedProofTypes, "The proofType list should not be null.");
         assertEquals(2, retrievedProofTypes.size(), "The proofType list should contain 2 elements.");
         assertTrue(retrievedProofTypes.contains("LdProof"), "The proofType list should contain 'LdProof'.");
@@ -29,9 +29,9 @@ public class VpFormatsTest {
 
     @Test
     public void testVpFormats_WithNullLdpVp() {
-        VpFormats vpFormats = new VpFormats(null,null);
+        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(null,null);
 
-        assertNull(vpFormats.getLdpVp(), "The LdpVp object should be null when initialized with null.");
+        assertNull(vpFormatsSupported.getLdpVp(), "The LdpVp object should be null when initialized with null.");
     }
 
     @Test
@@ -39,12 +39,12 @@ public class VpFormatsTest {
         List<String> proofTypes = Arrays.asList();
         LdpVp ldpVp = new LdpVp(proofTypes);
 
-        VpFormats vpFormats = new VpFormats(ldpVp,null);
+        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(ldpVp,null);
 
-        assertNotNull(vpFormats.getLdpVp(), "The LdpVp object should not be null.");
-        assertEquals(ldpVp, vpFormats.getLdpVp(), "The LdpVp object should match the one set in the constructor.");
+        assertNotNull(vpFormatsSupported.getLdpVp(), "The LdpVp object should not be null.");
+        assertEquals(ldpVp, vpFormatsSupported.getLdpVp(), "The LdpVp object should match the one set in the constructor.");
 
-        List<String> retrievedProofTypes = vpFormats.getLdpVp().getProofType();
+        List<String> retrievedProofTypes = vpFormatsSupported.getLdpVp().getProofType();
         assertNotNull(retrievedProofTypes, "The proofType list should not be null.");
         assertTrue(retrievedProofTypes.isEmpty(), "The proofType list should be empty.");
     }
@@ -55,9 +55,9 @@ public class VpFormatsTest {
 
         SdJwt sdJwt = new SdJwt(algs, proofTypes);
 
-        VpFormats vpFormats = new VpFormats(null, sdJwt);
+        VpFormatsSupported vpFormatsSupported = new VpFormatsSupported(null, sdJwt);
 
-        assertNotNull(vpFormats.getSdJwt(), "The SdJwt object should not be null.");
-        assertEquals(sdJwt, vpFormats.getSdJwt(), "The SdJwt object should match the one set in the constructor.");
+        assertNotNull(vpFormatsSupported.getSdJwt(), "The SdJwt object should not be null.");
+        assertEquals(sdJwt, vpFormatsSupported.getSdJwt(), "The SdJwt object should match the one set in the constructor.");
     }
 }

--- a/verify-service/src/test/java/io/inji/verify/shared/ConstantsTest.java
+++ b/verify-service/src/test/java/io/inji/verify/shared/ConstantsTest.java
@@ -1,7 +1,7 @@
 package io.inji.verify.shared;
 
 import io.inji.verify.dto.client.LdpVp;
-import io.inji.verify.dto.client.VpFormats;
+import io.inji.verify.dto.client.VpFormatsSupported;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -62,12 +62,12 @@ public class ConstantsTest {
     }
 
     @Test
-    @DisplayName("Verify VP_FORMATS configuration")
-    void testVpFormatsConstant() {
-        assertNotNull(Constants.VP_FORMATS);
-        assertInstanceOf(VpFormats.class, Constants.VP_FORMATS);
+    @DisplayName("Verify VP_FORMATS_SUPPORTED configuration")
+    void testVpFormatsSupportedConstant() {
+        assertNotNull(Constants.VP_FORMATS_SUPPORTED);
+        assertInstanceOf(VpFormatsSupported.class, Constants.VP_FORMATS_SUPPORTED);
 
-        LdpVp ldpVp = Constants.VP_FORMATS.getLdpVp();
+        LdpVp ldpVp = Constants.VP_FORMATS_SUPPORTED.getLdpVp();
         assertNotNull(ldpVp);
 
         List<String> proofTypes = ldpVp.getProofType();
@@ -108,7 +108,7 @@ public class ConstantsTest {
         assertNotNull(Constants.TRANSACTION_ID_PREFIX);
         assertNotNull(Constants.REQUEST_ID_PREFIX);
 
-        assertNotNull(Constants.VP_FORMATS);
+        assertNotNull(Constants.VP_FORMATS_SUPPORTED);
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected VP format metadata field in verification requests to use the supported key per OpenID4VP.

* **New Features**
  * Added a new VP format ("dc+sd-jwt") to supported presentation formats.
  * Updated supported JWT algorithm lists for SD-JWT-related formats.

* **Chores**
  * Package version bumped from 0.19.0-beta.3 to 0.19.0-beta.4.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inji/inji-verify/pull/1953)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->