### PR TITLE
Add INJI ownership notice to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+All INJI code is owned and maintained by International Institute of Information Technology, Bangalore, on behalf of INJI
+
 Mozilla Public License Version 2.0
 ==================================
 


### PR DESCRIPTION
This PR prepends the following line to the top of the LICENSE file:\n\n> All INJI code is owned and maintained by International Institute of Information Technology, Bangalore, on behalf of INJI\n\nNo other content is modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated LICENSE file with an ownership notice preceding the Mozilla Public License v2.0 terms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inji/inji-verify/pull/1997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->