### PR TITLE
#1935 updated type_values validations to test for absolute or relative IRI

### DIFF
--- a/docker-compose/config/config.json
+++ b/docker-compose/config/config.json
@@ -15,7 +15,7 @@
             "meta": {
               "type_values": [
                 [
-                  "MOSIPVerifiableCredential"
+                  "https://inji.github.io/inji-config/contexts/mosip-identity-context.json#MOSIPVerifiableCredential"
                 ]
               ]
             }
@@ -26,7 +26,7 @@
     {
       "logo": "/assets/cert.png",
       "name": "Life Insurance",
-      "type": "LifeInsuranceCredential",
+      "type": "InsuranceCredential",
       "clientIdPrefix": "decentralized_identifier",
       "purpose": "Relying party is requesting your digital ID for the purpose of Self-Authentication",
       "dcqlQuery": {
@@ -37,10 +37,11 @@
             "meta": {
               "type_values": [
                 [
-                  "LifeInsuranceCredential"
+                  "https://inji.github.io/inji-config/contexts/insurance-context.json#InsuranceCredential"
                 ]
               ]
-            }
+            },
+            "multiple": true
           }
         ]
       }
@@ -48,7 +49,7 @@
     {
       "logo": "/assets/cert.png",
       "name": "Health Insurance",
-      "type": "InsuranceCredential",
+      "type": "HealthCredential",
       "clientIdPrefix": "pre_registered",
       "purpose": "Relying party is requesting your digital ID for the purpose of Self-Authentication",
       "dcqlQuery": {
@@ -59,10 +60,11 @@
             "meta": {
               "type_values": [
                 [
-                  "InsuranceCredential"
+                  "https://inji.github.io/inji-config/contexts/insurance-context.json#InsuranceCredential"
                 ]
               ]
-            }
+            },
+            "multiple": true
           }
         ]
       }
@@ -77,7 +79,7 @@
         "credentials": [
           {
             "id": "mock_identity_sd_jwt_credential_id",
-            "format": "dc+sd-jwt",
+            "format": "vc+sd-jwt",
             "meta": {
               "vct_values": [
                 "MockVerifiableCredential_SD_JWT"
@@ -90,7 +92,7 @@
     {
       "logo": "/assets/cert.png",
       "name": "Land Registry",
-      "type": "LandStatementCredential",
+      "type": "RegistrationReceiptCredential",
       "clientIdPrefix": "decentralized_identifier",
       "purpose": "Relying party is requesting your digital ID for the purpose of Self-Authentication",
       "dcqlQuery": {
@@ -101,7 +103,7 @@
             "meta": {
               "type_values": [
                 [
-                  "LandStatementCredential"
+                  "https://inji.github.io/inji-config/contexts/landregistry-registration-receipt-context.json#RegistrationReceiptCredential"
                 ]
               ]
             }
@@ -192,7 +194,7 @@
       "id": "inji-wallet",
       "name": "Inji Wallet",
       "iconUrl": "/assets/inji-web-wallet-icon.svg",
-      "walletBaseUrl": "https://injiweb.dev-int-inji.mosip.net"
+      "walletBaseUrl": "https://injiweb.dev.mosip.net"
     }
   ]
 }

--- a/helm/inji-verify-ui/files/config.json
+++ b/helm/inji-verify-ui/files/config.json
@@ -15,7 +15,7 @@
             "meta": {
               "type_values": [
                 [
-                  "MOSIPVerifiableCredential"
+                  "https://inji.github.io/inji-config/contexts/mosip-identity-context.json#MOSIPVerifiableCredential"
                 ]
               ]
             }
@@ -26,7 +26,7 @@
     {
       "logo": "/assets/cert.png",
       "name": "Life Insurance",
-      "type": "LifeInsuranceCredential",
+      "type": "InsuranceCredential",
       "clientIdPrefix": "decentralized_identifier",
       "purpose": "Relying party is requesting your digital ID for the purpose of Self-Authentication",
       "dcqlQuery": {
@@ -37,10 +37,11 @@
             "meta": {
               "type_values": [
                 [
-                  "LifeInsuranceCredential"
+                  "https://inji.github.io/inji-config/contexts/insurance-context.json#InsuranceCredential"
                 ]
               ]
-            }
+            },
+            "multiple": true
           }
         ]
       }
@@ -48,7 +49,7 @@
     {
       "logo": "/assets/cert.png",
       "name": "Health Insurance",
-      "type": "InsuranceCredential",
+      "type": "HealthCredential",
       "clientIdPrefix": "pre_registered",
       "purpose": "Relying party is requesting your digital ID for the purpose of Self-Authentication",
       "dcqlQuery": {
@@ -59,10 +60,11 @@
             "meta": {
               "type_values": [
                 [
-                  "InsuranceCredential"
+                  "https://inji.github.io/inji-config/contexts/insurance-context.json#InsuranceCredential"
                 ]
               ]
-            }
+            },
+            "multiple": true
           }
         ]
       }
@@ -77,7 +79,7 @@
         "credentials": [
           {
             "id": "mock_identity_sd_jwt_credential_id",
-            "format": "dc+sd-jwt",
+            "format": "vc+sd-jwt",
             "meta": {
               "vct_values": [
                 "MockVerifiableCredential_SD_JWT"
@@ -90,7 +92,7 @@
     {
       "logo": "/assets/cert.png",
       "name": "Land Registry",
-      "type": "LandStatementCredential",
+      "type": "RegistrationReceiptCredential",
       "clientIdPrefix": "decentralized_identifier",
       "purpose": "Relying party is requesting your digital ID for the purpose of Self-Authentication",
       "dcqlQuery": {
@@ -101,7 +103,7 @@
             "meta": {
               "type_values": [
                 [
-                  "LandStatementCredential"
+                  "https://inji.github.io/inji-config/contexts/landregistry-registration-receipt-context.json#RegistrationReceiptCredential"
                 ]
               ]
             }
@@ -188,11 +190,11 @@
   },
   "WebWallets": [
     {
-      "_note": "Replace walletBaseUrl with your own Inji Web Wallet URL. Accepts absolute URLs (https://wallet.example.org) or same-env relative paths (/wallet). Empty string disables the entry.",
+      "_note": "EXTERNAL DEPENDENCY: walletBaseUrl points to a shared dev/integration host. Replace with your own URL before use. Accepts absolute URLs (https://wallet.example.org) or same-env relative paths (/wallet). Empty string disables the entry. See docker-compose/README.md \u00a7 WebWallets Configuration.",
       "id": "inji-wallet",
       "name": "Inji Wallet",
       "iconUrl": "/assets/inji-web-wallet-icon.svg",
-      "walletBaseUrl": "https://from-install.sh"
+      "walletBaseUrl": "https://injiweb.dev.mosip.net"
     }
   ]
 }

--- a/verify-service/src/main/java/io/inji/verify/enums/ErrorCode.java
+++ b/verify-service/src/main/java/io/inji/verify/enums/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     DCQL_CREDENTIAL_FORMAT_INVALID("dcql_query.credentials","DCQL credential format must be a valid format."),
     DCQL_META_REQUIRED("dcql_query.credentials","Each DCQL credential entry must contain meta."),
     DCQL_META_INVALID("dcql_query.credentials","DCQL meta must not contain null/blank values."),
+    DCQL_META_TYPE_VALUE_INVALID_IRI("dcql_query.credentials","Each value in type_values must be a valid IRI (absolute or relative)."),
     DCQL_META_DUPLICATES("dcql_query.credentials","DCQL meta must not contain duplicate values."),
     DCQL_META_NOT_MATCHING_FORMAT("dcql_query.credentials","DCQL meta fields must match the specified credential format."),
     DCQL_CLAIM_ID_INVALID("dcql_query.credentials","Claim id must contain only alphanumeric characters, underscores, and hyphens."),

--- a/verify-service/src/main/java/io/inji/verify/utils/Utils.java
+++ b/verify-service/src/main/java/io/inji/verify/utils/Utils.java
@@ -138,15 +138,21 @@ public final class Utils {
 
     /**
      * Returns true if a credential's type value satisfies a required type from type_values.
-     * Supports both exact match and fragment match:
-     *   "VerifiableCredential" matches "https://www.w3.org/2018/credentials#VerifiableCredential"
+     * Supports exact match and local-name extraction via two IRI separators:
+     *   '#' fragment:  "VerifiableCredential" matches "https://www.w3.org/2018/credentials#VerifiableCredential"
+     *   '/' path:      "DriversLicense"       matches "https://example.org/types/DriversLicense"
      * Per DCQL spec: if a type is not defined in any @context it remains a relative IRI,
-     * so JSON-LD processing may be skipped and the fragment is treated as the expanded type.
+     * so JSON-LD processing may be skipped and the local name is treated as the expanded type.
+     * '#' is tried before '/' because fragment identifiers are the more common IRI pattern in VC contexts.
      */
     public static boolean ldpTypeMatches(String credentialType, String requiredType) {
         if (credentialType.equals(requiredType)) return true;
-        int fragmentIndex = requiredType.lastIndexOf('#');
-        return fragmentIndex >= 0 && credentialType.equals(requiredType.substring(fragmentIndex + 1));
+        int hashIndex = requiredType.lastIndexOf('#');
+        if (hashIndex >= 0) {
+            return credentialType.equals(requiredType.substring(hashIndex + 1));
+        }
+        int slashIndex = requiredType.lastIndexOf('/');
+        return slashIndex >= 0 && credentialType.equals(requiredType.substring(slashIndex + 1));
     }
 
     /**

--- a/verify-service/src/main/java/io/inji/verify/validator/DcqlValidator.java
+++ b/verify-service/src/main/java/io/inji/verify/validator/DcqlValidator.java
@@ -13,6 +13,8 @@ import com.authlete.sd.Disclosure;
 import com.authlete.sd.SDJWT;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -218,14 +220,50 @@ public class DcqlValidator {
     private static void validateMetaValues(CredentialMetaDto meta) {
         if (meta.getVctValues() != null &&
                 meta.getVctValues().size() != new HashSet<>(meta.getVctValues()).size()) {
-            throw new VPRequestValidationException(
-                    ErrorCode.DCQL_META_DUPLICATES);
+            throw new VPRequestValidationException(ErrorCode.DCQL_META_DUPLICATES);
         }
 
-        if (meta.getTypeValues() != null &&
-                meta.getTypeValues().size() != new HashSet<>(meta.getTypeValues()).size()) {
-            throw new VPRequestValidationException(
-                    ErrorCode.DCQL_META_DUPLICATES);
+        if (meta.getTypeValues() != null) {
+            // Outer array must be non-empty
+            if (meta.getTypeValues().isEmpty()) {
+                throw new VPRequestValidationException(ErrorCode.DCQL_META_INVALID);
+            }
+            // Duplicate outer options not allowed
+            if (meta.getTypeValues().size() != new HashSet<>(meta.getTypeValues()).size()) {
+                throw new VPRequestValidationException(ErrorCode.DCQL_META_DUPLICATES);
+            }
+            for (List<String> option : meta.getTypeValues()) {
+                // Each inner array must be non-empty (it is a set of types that must ALL be present)
+                if (option.isEmpty()) {
+                    throw new VPRequestValidationException(ErrorCode.DCQL_META_INVALID);
+                }
+                // Duplicate types within a single inner array are not allowed
+                // (inner array is a type set — duplicates are meaningless and indicate a malformed query)
+                if (option.size() != new HashSet<>(option).size()) {
+                    throw new VPRequestValidationException(ErrorCode.DCQL_META_DUPLICATES);
+                }
+                for (String typeValue : option) {
+                    if (!isValidIri(typeValue)) {
+                        throw new VPRequestValidationException(ErrorCode.DCQL_META_TYPE_VALUE_INVALID_IRI);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns true if the string is a valid IRI reference (absolute or relative).
+     * Per the DCQL spec, if a type is not defined in any @context it remains unchanged
+     * after JSON-LD processing — i.e. relative IRIs like "VerifiableCredential" or
+     * "MockVerifiableCredential" are fully expanded types and are valid type_values entries.
+     * Only rejects strings with characters illegal in an IRI (e.g. unencoded spaces).
+     */
+    private static boolean isValidIri(String value) {
+        try {
+            new URI(value);
+            return true;
+        } catch (URISyntaxException e) {
+            return false;
         }
     }
 

--- a/verify-service/src/main/java/io/inji/verify/validator/DcqlValidator.java
+++ b/verify-service/src/main/java/io/inji/verify/validator/DcqlValidator.java
@@ -218,9 +218,15 @@ public class DcqlValidator {
     }
 
     private static void validateMetaValues(CredentialMetaDto meta) {
-        if (meta.getVctValues() != null &&
-                meta.getVctValues().size() != new HashSet<>(meta.getVctValues()).size()) {
-            throw new VPRequestValidationException(ErrorCode.DCQL_META_DUPLICATES);
+        if (meta.getVctValues() != null) {
+            for (String vctValue : meta.getVctValues()) {
+                if (vctValue == null || vctValue.isBlank()) {
+                    throw new VPRequestValidationException(ErrorCode.DCQL_META_INVALID);
+                }
+            }
+            if (meta.getVctValues().size() != new HashSet<>(meta.getVctValues()).size()) {
+                throw new VPRequestValidationException(ErrorCode.DCQL_META_DUPLICATES);
+            }
         }
 
         if (meta.getTypeValues() != null) {
@@ -233,16 +239,18 @@ public class DcqlValidator {
                 throw new VPRequestValidationException(ErrorCode.DCQL_META_DUPLICATES);
             }
             for (List<String> option : meta.getTypeValues()) {
-                // Each inner array must be non-empty (it is a set of types that must ALL be present)
-                if (option.isEmpty()) {
+                // Each inner array must be non-null and non-empty
+                if (option == null || option.isEmpty()) {
                     throw new VPRequestValidationException(ErrorCode.DCQL_META_INVALID);
                 }
                 // Duplicate types within a single inner array are not allowed
-                // (inner array is a type set — duplicates are meaningless and indicate a malformed query)
                 if (option.size() != new HashSet<>(option).size()) {
                     throw new VPRequestValidationException(ErrorCode.DCQL_META_DUPLICATES);
                 }
                 for (String typeValue : option) {
+                    if (typeValue == null || typeValue.isBlank()) {
+                        throw new VPRequestValidationException(ErrorCode.DCQL_META_INVALID);
+                    }
                     if (!isValidIri(typeValue)) {
                         throw new VPRequestValidationException(ErrorCode.DCQL_META_TYPE_VALUE_INVALID_IRI);
                     }

--- a/verify-service/src/test/java/io/inji/verify/validator/DcqlQueryValidatorTest.java
+++ b/verify-service/src/test/java/io/inji/verify/validator/DcqlQueryValidatorTest.java
@@ -284,6 +284,84 @@ class DcqlQueryValidatorTest {
         assertEquals(ErrorCode.DCQL_META_DUPLICATES, ex.getErrorCode());
     }
 
+    @Test
+    void shouldFail_whenTypeValuesOuterArrayIsEmpty() {
+        // type_values: [] — outer array must be non-empty per spec
+        CredentialMetaDto meta = new CredentialMetaDto(null, List.of());
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(credWithMeta("c", Constants.FORMAT_LDP_VC, meta)), null);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> validator.validate(query));
+
+        assertEquals(ErrorCode.DCQL_META_INVALID, ex.getErrorCode());
+    }
+
+    @Test
+    void shouldFail_whenTypeValuesInnerArrayIsEmpty() {
+        // type_values: [[]] — each inner array (AND-set) must not be empty
+        CredentialMetaDto meta = new CredentialMetaDto(null, List.of(List.of()));
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(credWithMeta("c", Constants.FORMAT_LDP_VC, meta)), null);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> validator.validate(query));
+
+        assertEquals(ErrorCode.DCQL_META_INVALID, ex.getErrorCode());
+    }
+
+    @Test
+    void shouldFail_whenTypeValuesInnerArrayContainsDuplicateTypes() {
+        // type_values: [["A", "A"]] — duplicate within an AND-set is invalid
+        CredentialMetaDto meta = new CredentialMetaDto(null,
+                List.of(List.of("VerifiableCredential", "VerifiableCredential")));
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(credWithMeta("c", Constants.FORMAT_LDP_VC, meta)), null);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> validator.validate(query));
+
+        assertEquals(ErrorCode.DCQL_META_DUPLICATES, ex.getErrorCode());
+    }
+
+    @Test
+    void shouldPass_whenTypeValuesContainAbsoluteIris() {
+        List<List<String>> typeValues = List.of(
+                List.of("https://www.w3.org/2018/credentials#VerifiableCredential",
+                        "https://example.org/types/UniversityDegreeCredential"));
+        CredentialMetaDto meta = new CredentialMetaDto(null, typeValues);
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(credWithMeta("c", Constants.FORMAT_LDP_VC, meta)), null);
+
+        assertDoesNotThrow(() -> validator.validate(query));
+    }
+
+    @Test
+    void shouldPass_whenTypeValuesContainRelativeIris() {
+        // Per spec, a type not defined in any @context remains a relative IRI after JSON-LD processing
+        // and that relative IRI IS the fully expanded type — so it must be accepted.
+        List<List<String>> typeValues = List.of(List.of("VerifiableCredential", "UniversityDegreeCredential"));
+        CredentialMetaDto meta = new CredentialMetaDto(null, typeValues);
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(credWithMeta("c", Constants.FORMAT_LDP_VC, meta)), null);
+
+        assertDoesNotThrow(() -> validator.validate(query));
+    }
+
+    @Test
+    void shouldFail_whenTypeValuesContainMalformedIri() {
+        // A string with spaces or illegal characters is not a valid IRI reference
+        List<List<String>> typeValues = List.of(List.of("not a valid iri"));
+        CredentialMetaDto meta = new CredentialMetaDto(null, typeValues);
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(credWithMeta("c", Constants.FORMAT_LDP_VC, meta)), null);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> validator.validate(query));
+
+        assertEquals(ErrorCode.DCQL_META_TYPE_VALUE_INVALID_IRI, ex.getErrorCode());
+    }
+
     // -------------------------------------------------------------------------
     // validateClaimIds — format and uniqueness
     // -------------------------------------------------------------------------

--- a/verify-service/src/test/java/io/inji/verify/validator/DcqlQueryValidatorTest.java
+++ b/verify-service/src/test/java/io/inji/verify/validator/DcqlQueryValidatorTest.java
@@ -11,6 +11,7 @@ import io.inji.verify.shared.Constants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -322,6 +323,61 @@ class DcqlQueryValidatorTest {
                 () -> validator.validate(query));
 
         assertEquals(ErrorCode.DCQL_META_DUPLICATES, ex.getErrorCode());
+    }
+
+    @Test
+    void shouldFail_whenTypeValuesInnerArrayContainsNullEntry() {
+        List<String> option = new ArrayList<>();
+        option.add("VerifiableCredential");
+        option.add(null);
+        CredentialMetaDto meta = new CredentialMetaDto(null, List.of(option));
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(credWithMeta("c", Constants.FORMAT_LDP_VC, meta)), null);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> validator.validate(query));
+
+        assertEquals(ErrorCode.DCQL_META_INVALID, ex.getErrorCode());
+    }
+
+    @Test
+    void shouldFail_whenTypeValuesInnerArrayContainsBlankEntry() {
+        CredentialMetaDto meta = new CredentialMetaDto(null,
+                List.of(List.of("VerifiableCredential", "   ")));
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(credWithMeta("c", Constants.FORMAT_LDP_VC, meta)), null);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> validator.validate(query));
+
+        assertEquals(ErrorCode.DCQL_META_INVALID, ex.getErrorCode());
+    }
+
+    @Test
+    void shouldFail_whenVctValuesContainsNullEntry() {
+        List<String> vctValues = new ArrayList<>();
+        vctValues.add("https://example.org/vct/MyCredential");
+        vctValues.add(null);
+        CredentialMetaDto meta = new CredentialMetaDto(vctValues, null);
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(credWithMeta("c", Constants.FORMAT_DC_SD_JWT, meta)), null);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> validator.validate(query));
+
+        assertEquals(ErrorCode.DCQL_META_INVALID, ex.getErrorCode());
+    }
+
+    @Test
+    void shouldFail_whenVctValuesContainsBlankEntry() {
+        CredentialMetaDto meta = new CredentialMetaDto(List.of("https://example.org/vct/MyCredential", "  "), null);
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(credWithMeta("c", Constants.FORMAT_DC_SD_JWT, meta)), null);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> validator.validate(query));
+
+        assertEquals(ErrorCode.DCQL_META_INVALID, ex.getErrorCode());
     }
 
     @Test

--- a/verify-service/src/test/java/io/inji/verify/validator/DcqlVpTokenValidatorTest.java
+++ b/verify-service/src/test/java/io/inji/verify/validator/DcqlVpTokenValidatorTest.java
@@ -711,7 +711,7 @@ class DcqlVpTokenValidatorTest {
 
     @Test
     void shouldPass_whenCredentialTypesMatchFullIriOption() {
-        // DCQL uses full IRIs; credential uses relative type names — fragment match must succeed.
+        // DCQL uses full IRIs with # separator; credential uses relative type names — fragment match must succeed.
         // e.g. "https://example.org/examples#UniversityDegreeCredential" must match "UniversityDegreeCredential".
         DCQLQueryDto query = new DCQLQueryDto(List.of(credWithTypeValues("cred1", List.of(
                 List.of(
@@ -721,6 +721,34 @@ class DcqlVpTokenValidatorTest {
         ))), null);
         assertDoesNotThrow(() -> validator.validateVpTokenAgainstDcql(query,
                 ldpVcTokenWithTypes("cred1", "UniversityDegreeCredential")));
+    }
+
+    @Test
+    void shouldPass_whenCredentialTypesMatchFullIriWithSlashSeparator() {
+        // DCQL uses full IRIs with / path separator; credential uses relative type name — path match must succeed.
+        // e.g. "https://example.org/types/DriversLicense" must match "DriversLicense".
+        DCQLQueryDto query = new DCQLQueryDto(List.of(credWithTypeValues("cred1", List.of(
+                List.of(
+                        "https://www.w3.org/2018/credentials#VerifiableCredential",
+                        "https://example.org/types/DriversLicense"
+                )
+        ))), null);
+        assertDoesNotThrow(() -> validator.validateVpTokenAgainstDcql(query,
+                ldpVcTokenWithTypes("cred1", "VerifiableCredential", "DriversLicense")));
+    }
+
+    @Test
+    void shouldFail_whenCredentialTypeMatchesNeitherHashNorSlashSeparator() {
+        // Credential has "Other" but query requires "DriversLicense" via / path — must not match.
+        DCQLQueryDto query = new DCQLQueryDto(List.of(credWithTypeValues("cred1", List.of(
+                List.of("https://example.org/types/DriversLicense")
+        ))), null);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> validator.validateVpTokenAgainstDcql(query,
+                        ldpVcTokenWithTypes("cred1", "Other")));
+
+        assertEquals(ErrorCode.VP_TOKEN_META_TYPE_VALUES_MISMATCH, ex.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
#1935 updated type_values validations to test for absolute or relative IRI, 
added slash comparison in addition to hash when matching VP token with DCQL ,
added junits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced validation for credential type values to ensure proper format compliance
  * Updated credential type definitions for MOSIP ID, Insurance, and Land Registry credentials
  * Improved credential type matching to support multiple IRI format patterns

* **Configuration Updates**
  * Updated Inji wallet base URL
  * Modified SD JWT format identifier for Mock Identity credential

<!-- end of auto-generated comment: release notes by coderabbit.ai -->