### PR TITLE
#2045 Fixed nonce validation and generation gaps in VP request creation

### DIFF
--- a/docs/Inji_Verify_Postman_Collection.json
+++ b/docs/Inji_Verify_Postman_Collection.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "_postman_id": "17e0cb2b-cc7a-4aff-a694-2d9a90c369f8",
+    "_postman_id": "1d23d6ca-4b65-4ed4-898a-8266bd35279e",
     "name": "Inji_Verify_Postman_Collection",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_exporter_id": "12594460"
@@ -266,7 +266,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"verifiableCredential\": \"{\\\"credentialSubject\\\":{\\\"VID\\\":9876543210,\\\"gender\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Male\\\"},{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"M\u00e2le\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"\u0630\u0643\u0631\\\"}],\\\"province\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"phone\\\":\\\"+919427357934\\\",\\\"postalCode\\\":45009,\\\"fullName\\\":[{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"\u062a\u062a\u06af\u0644\u062f\u0643\u0646\u0633\u064e\u0632\u0642\u0647\u0650\u0642\u0650\u0641\u0644 \u062f\u0633\u064a\u064a\u0633\u064a\u0643\u062f\u0643\u0646\u0648\u06a4\u0648\\\"},{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"}],\\\"dateOfBirth\\\":\\\"1987/11/25\\\",\\\"id\\\":\\\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\\\",\\\"UIN\\\":9876543210,\\\"region\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"email\\\":\\\"siddhartha.km@gmail.com\\\"},\\\"validUntil\\\":\\\"2028-01-08T07:19:56.385Z\\\",\\\"validFrom\\\":\\\"2026-01-08T07:19:56.385Z\\\",\\\"id\\\":\\\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\\\",\\\"type\\\":[\\\"VerifiableCredential\\\",\\\"MockVerifiableCredential\\\"],\\\"@context\\\":[\\\"https://www.w3.org/ns/credentials/v2\\\",\\\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\\\",\\\"https://w3id.org/security/suites/ed25519-2020/v1\\\"],\\\"issuer\\\":\\\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\\\",\\\"credentialStatus\\\":{\\\"statusPurpose\\\":\\\"revocation\\\",\\\"statusListIndex\\\":\\\"94010\\\",\\\"id\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\\\",\\\"type\\\":\\\"BitstringStatusListEntry\\\",\\\"statusListCredential\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\\\"},\\\"proof\\\":{\\\"type\\\":\\\"Ed25519Signature2020\\\",\\\"created\\\":\\\"2026-01-08T07:19:56Z\\\",\\\"proofPurpose\\\":\\\"assertionMethod\\\",\\\"verificationMethod\\\":\\\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity#BF6EnRlmWN2x2T0HsTBbDtbci_dD2qYPdtxlVpv2Lz8\\\",\\\"proofValue\\\":\\\"z2jBgb8JmCH3b5LyfeqF1gFsgBTmQcr18hTD98SDGhoL3Nrr8vwjWw7iGxVECYz9yD5SWCrPP83YAQ81yH2WvDY1b\\\"}}\",\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\"],\n  \"includeClaims\": false\n}",
+                  "raw": "{\n  \"verifiableCredential\": \"{\\\"credentialSubject\\\":{\\\"VID\\\":9876543210,\\\"gender\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Male\\\"},{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"Mâle\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"ذكر\\\"}],\\\"province\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"phone\\\":\\\"+919427357934\\\",\\\"postalCode\\\":45009,\\\"fullName\\\":[{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"تتگلدكنسَزقهِقِفل دسييسيكدكنوڤو\\\"},{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"}],\\\"dateOfBirth\\\":\\\"1987/11/25\\\",\\\"id\\\":\\\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\\\",\\\"UIN\\\":9876543210,\\\"region\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"email\\\":\\\"siddhartha.km@gmail.com\\\"},\\\"validUntil\\\":\\\"2028-01-08T07:19:56.385Z\\\",\\\"validFrom\\\":\\\"2026-01-08T07:19:56.385Z\\\",\\\"id\\\":\\\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\\\",\\\"type\\\":[\\\"VerifiableCredential\\\",\\\"MockVerifiableCredential\\\"],\\\"@context\\\":[\\\"https://www.w3.org/ns/credentials/v2\\\",\\\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\\\",\\\"https://w3id.org/security/suites/ed25519-2020/v1\\\"],\\\"issuer\\\":\\\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\\\",\\\"credentialStatus\\\":{\\\"statusPurpose\\\":\\\"revocation\\\",\\\"statusListIndex\\\":\\\"94010\\\",\\\"id\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\\\",\\\"type\\\":\\\"BitstringStatusListEntry\\\",\\\"statusListCredential\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\\\"},\\\"proof\\\":{\\\"type\\\":\\\"Ed25519Signature2020\\\",\\\"created\\\":\\\"2026-01-08T07:19:56Z\\\",\\\"proofPurpose\\\":\\\"assertionMethod\\\",\\\"verificationMethod\\\":\\\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity#BF6EnRlmWN2x2T0HsTBbDtbci_dD2qYPdtxlVpv2Lz8\\\",\\\"proofValue\\\":\\\"z2jBgb8JmCH3b5LyfeqF1gFsgBTmQcr18hTD98SDGhoL3Nrr8vwjWw7iGxVECYz9yD5SWCrPP83YAQ81yH2WvDY1b\\\"}}\",\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\"],\n  \"includeClaims\": false\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -360,7 +360,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"verifiableCredential\": \"{\\\"credentialSubject\\\":{\\\"VID\\\":9876543210,\\\"gender\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Male\\\"},{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"M\u00e2le\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"\u0630\u0643\u0631\\\"}],\\\"province\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"phone\\\":\\\"+919427357934\\\",\\\"postalCode\\\":45009,\\\"fullName\\\":[{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"\u062a\u062a\u06af\u0644\u062f\u0643\u0646\u0633\u064e\u0632\u0642\u0647\u0650\u0642\u0650\u0641\u0644 \u062f\u0633\u064a\u064a\u0633\u064a\u0643\u062f\u0643\u0646\u0648\u06a4\u0648\\\"},{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"}],\\\"dateOfBirth\\\":\\\"1987/11/25\\\",\\\"id\\\":\\\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\\\",\\\"UIN\\\":9876543210,\\\"region\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"email\\\":\\\"siddhartha.km@gmail.com\\\"},\\\"validUntil\\\":\\\"2028-01-08T07:19:56.385Z\\\",\\\"validFrom\\\":\\\"2026-01-08T07:19:56.385Z\\\",\\\"id\\\":\\\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\\\",\\\"type\\\":[\\\"VerifiableCredential\\\",\\\"MockVerifiableCredential\\\"],\\\"@context\\\":[\\\"https://www.w3.org/ns/credentials/v2\\\",\\\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\\\",\\\"https://w3id.org/security/suites/ed25519-2020/v1\\\"],\\\"issuer\\\":\\\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\\\",\\\"credentialStatus\\\":{\\\"statusPurpose\\\":\\\"revocation\\\",\\\"statusListIndex\\\":\\\"94010\\\",\\\"id\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\\\",\\\"type\\\":\\\"BitstringStatusListEntry\\\",\\\"statusListCredential\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\\\"},\\\"proof\\\":{\\\"verificationMethod\\\":\\\"did:web:mosip.github.io:inji-config:qa-inji1:landregistry#UHNnpAY2hEkSnXqkc3aS07EgTEaw9WC64kpO3jvP9X0\\\",\\\"created\\\":\\\"2025-11-24T07:37:30Z\\\",\\\"type\\\":\\\"Ed25519Signature2020\\\",\\\"proofPurpose\\\":\\\"assertionMethod\\\",\\\"proofValue\\\":\\\"z5gfKobfm77qMGgs41LDkoSjZdS7fTx19runRBxPSckQUfCxMgbmnF9SiGwgJrkuzx1yYqdvkfW7u69v5cMc3ePCp\\\"}}\",\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\"],\n  \"includeClaims\": true\n}",
+                  "raw": "{\n  \"verifiableCredential\": \"{\\\"credentialSubject\\\":{\\\"VID\\\":9876543210,\\\"gender\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Male\\\"},{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"Mâle\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"ذكر\\\"}],\\\"province\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"phone\\\":\\\"+919427357934\\\",\\\"postalCode\\\":45009,\\\"fullName\\\":[{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"تتگلدكنسَزقهِقِفل دسييسيكدكنوڤو\\\"},{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"}],\\\"dateOfBirth\\\":\\\"1987/11/25\\\",\\\"id\\\":\\\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\\\",\\\"UIN\\\":9876543210,\\\"region\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"email\\\":\\\"siddhartha.km@gmail.com\\\"},\\\"validUntil\\\":\\\"2028-01-08T07:19:56.385Z\\\",\\\"validFrom\\\":\\\"2026-01-08T07:19:56.385Z\\\",\\\"id\\\":\\\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\\\",\\\"type\\\":[\\\"VerifiableCredential\\\",\\\"MockVerifiableCredential\\\"],\\\"@context\\\":[\\\"https://www.w3.org/ns/credentials/v2\\\",\\\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\\\",\\\"https://w3id.org/security/suites/ed25519-2020/v1\\\"],\\\"issuer\\\":\\\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\\\",\\\"credentialStatus\\\":{\\\"statusPurpose\\\":\\\"revocation\\\",\\\"statusListIndex\\\":\\\"94010\\\",\\\"id\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\\\",\\\"type\\\":\\\"BitstringStatusListEntry\\\",\\\"statusListCredential\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\\\"},\\\"proof\\\":{\\\"verificationMethod\\\":\\\"did:web:mosip.github.io:inji-config:qa-inji1:landregistry#UHNnpAY2hEkSnXqkc3aS07EgTEaw9WC64kpO3jvP9X0\\\",\\\"created\\\":\\\"2025-11-24T07:37:30Z\\\",\\\"type\\\":\\\"Ed25519Signature2020\\\",\\\"proofPurpose\\\":\\\"assertionMethod\\\",\\\"proofValue\\\":\\\"z5gfKobfm77qMGgs41LDkoSjZdS7fTx19runRBxPSckQUfCxMgbmnF9SiGwgJrkuzx1yYqdvkfW7u69v5cMc3ePCp\\\"}}\",\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\"],\n  \"includeClaims\": true\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -407,7 +407,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"verifiableCredential\": \"{\\\"credentialSubject\\\":{\\\"VID\\\":9876543210,\\\"gender\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Male\\\"},{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"M\u00e2le\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"\u0630\u0643\u0631\\\"}],\\\"province\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"phone\\\":\\\"+919427357934\\\",\\\"postalCode\\\":45009,\\\"fullName\\\":[{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"\u062a\u062a\u06af\u0644\u062f\u0643\u0646\u0633\u064e\u0632\u0642\u0647\u0650\u0642\u0650\u0641\u0644 \u062f\u0633\u064a\u064a\u0633\u064a\u0643\u062f\u0643\u0646\u0648\u06a4\u0648\\\"},{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"}],\\\"dateOfBirth\\\":\\\"1987/11/25\\\",\\\"id\\\":\\\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\\\",\\\"UIN\\\":9876543210,\\\"region\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"email\\\":\\\"siddhartha.km@gmail.com\\\"},\\\"validUntil\\\":\\\"2028-01-08T07:19:56.385Z\\\",\\\"validFrom\\\":\\\"2026-01-08T07:19:56.385Z\\\",\\\"id\\\":\\\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\\\",\\\"type\\\":[\\\"VerifiableCredential\\\",\\\"MockVerifiableCredential\\\"],\\\"@context\\\":[\\\"https://www.w3.org/ns/credentials/v2\\\",\\\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\\\",\\\"https://w3id.org/security/suites/ed25519-2020/v1\\\"],\\\"issuer\\\":\\\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\\\",\\\"credentialStatus\\\":{\\\"statusPurpose\\\":\\\"revocation\\\",\\\"statusListIndex\\\":\\\"94010\\\",\\\"id\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\\\",\\\"type\\\":\\\"BitstringStatusListEntry\\\",\\\"statusListCredential\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\\\"}}\",\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\"],\n  \"includeClaims\": true\n}",
+                  "raw": "{\n  \"verifiableCredential\": \"{\\\"credentialSubject\\\":{\\\"VID\\\":9876543210,\\\"gender\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Male\\\"},{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"Mâle\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"ذكر\\\"}],\\\"province\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"phone\\\":\\\"+919427357934\\\",\\\"postalCode\\\":45009,\\\"fullName\\\":[{\\\"language\\\":\\\"fra\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"},{\\\"language\\\":\\\"ara\\\",\\\"value\\\":\\\"تتگلدكنسَزقهِقِفل دسييسيكدكنوڤو\\\"},{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"Siddharth K Mansour\\\"}],\\\"dateOfBirth\\\":\\\"1987/11/25\\\",\\\"id\\\":\\\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\\\",\\\"UIN\\\":9876543210,\\\"region\\\":[{\\\"language\\\":\\\"eng\\\",\\\"value\\\":\\\"yuanwee\\\"}],\\\"email\\\":\\\"siddhartha.km@gmail.com\\\"},\\\"validUntil\\\":\\\"2028-01-08T07:19:56.385Z\\\",\\\"validFrom\\\":\\\"2026-01-08T07:19:56.385Z\\\",\\\"id\\\":\\\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\\\",\\\"type\\\":[\\\"VerifiableCredential\\\",\\\"MockVerifiableCredential\\\"],\\\"@context\\\":[\\\"https://www.w3.org/ns/credentials/v2\\\",\\\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\\\",\\\"https://w3id.org/security/suites/ed25519-2020/v1\\\"],\\\"issuer\\\":\\\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\\\",\\\"credentialStatus\\\":{\\\"statusPurpose\\\":\\\"revocation\\\",\\\"statusListIndex\\\":\\\"94010\\\",\\\"id\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\\\",\\\"type\\\":\\\"BitstringStatusListEntry\\\",\\\"statusListCredential\\\":\\\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\\\"}}\",\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\"],\n  \"includeClaims\": true\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -742,7 +742,7 @@
               "script": {
                 "exec": [
                   "var responseJson = pm.response.json();",
-                  "pm.collectionVariables.set('txnIdForJSON_Ld', responseJson.transactionId);",
+                  "pm.collectionVariables.set('vc_sub_jsonLd_txnId', responseJson.transactionId);",
                   "pm.test(\"Status code is 200\", function () {",
                   "    pm.response.to.have.status(200);",
                   "});"
@@ -806,7 +806,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForJSON_Ld}}",
+              "raw": "{{base_url}}/v1/verify/vp-result/{{vc_sub_jsonLd_txnId}}",
               "host": [
                 "{{base_url}}"
               ],
@@ -814,7 +814,7 @@
                 "v1",
                 "verify",
                 "vp-result",
-                "{{txnIdForJSON_Ld}}"
+                "{{vc_sub_jsonLd_txnId}}"
               ]
             }
           },
@@ -828,7 +828,7 @@
               "script": {
                 "exec": [
                   "var responseJson = pm.response.json();",
-                  "pm.collectionVariables.set('txnIdForSD_JWT', responseJson.transactionId);",
+                  "pm.collectionVariables.set('vc_sub_sdJwt_txnId', responseJson.transactionId);",
                   "",
                   "pm.test(\"Status code is 200\", function () {",
                   "    pm.response.to.have.status(200);",
@@ -893,7 +893,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForSD_JWT}}",
+              "raw": "{{base_url}}/v1/verify/vp-result/{{vc_sub_sdJwt_txnId}}",
               "host": [
                 "{{base_url}}"
               ],
@@ -901,7 +901,7 @@
                 "v1",
                 "verify",
                 "vp-result",
-                "{{txnIdForSD_JWT}}"
+                "{{vc_sub_sdJwt_txnId}}"
               ]
             }
           },
@@ -915,7 +915,7 @@
               "script": {
                 "exec": [
                   "var responseJson = pm.response.json();",
-                  "pm.collectionVariables.set('txnIdForCWT', responseJson.transactionId);",
+                  "pm.collectionVariables.set('vc_sub_cwt_txnId', responseJson.transactionId);",
                   "",
                   "pm.test(\"Status code is 200\", function () {",
                   "    pm.response.to.have.status(200);",
@@ -980,7 +980,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForCWT}}",
+              "raw": "{{base_url}}/v1/verify/vp-result/{{vc_sub_cwt_txnId}}",
               "host": [
                 "{{base_url}}"
               ],
@@ -988,7 +988,7 @@
                 "v1",
                 "verify",
                 "vp-result",
-                "{{txnIdForCWT}}"
+                "{{vc_sub_cwt_txnId}}"
               ]
             }
           },
@@ -1000,7 +1000,7 @@
       "name": "openid4vp",
       "item": [
         {
-          "name": "1.8. sd-jwt - valid signature - dcql request",
+          "name": "1.1 ldp_vp - valid signature - dcql request",
           "item": [
             {
               "name": "vp request using dcql",
@@ -1010,8 +1010,8 @@
                   "script": {
                     "exec": [
                       "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
+                      "pm.collectionVariables.set('1_1_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('1_1_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -1031,7 +1031,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"MTc3OTEwMTI1ODkzOQ==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"vc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"eu.europa.ec.eudi.msisdn.1\"\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false,\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"registered_family_name\",\r\n                        \"path\": [\r\n                            \"registered_family_name\"\r\n                        ],\r\n                        \"values\": [\"Musterman\"]\r\n                    },\r\n                    {\r\n                        \"id\": \"phone_number\",\r\n                        \"path\": [\r\n                            \"phone_number\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"verification_method_information\",\r\n                        \"path\": [\r\n                            \"verification_method_information\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"phone_number\",\r\n                        \"verification_method_information\"\r\n                    ],\r\n                    [\r\n                        \"registered_family_name\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net/\",\r\n    \"nonce\": \"NkdHJkBIbdOdQaAjWm8gpA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"dc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"student_id_credential\"\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"last_name\",\r\n                        \"path\": [\r\n                            \"last_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"first_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"given_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"first_name\",\r\n                        \"last_name\"\r\n                    ],\r\n                    [\r\n                        \"given_name\"\r\n                    ]\r\n                ]\r\n            },\r\n            {\r\n                \"id\": \"mosip_verifiable_credential_id\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"male_gender\",\r\n                        \"path\": [\r\n                            \"gender\",\r\n                            null,\r\n                            \"value\"\r\n                        ],\r\n                        \"values\": [\"MLE\"]\r\n                    },\r\n                    {\r\n                        \"id\": \"full_name_eng\",\r\n                        \"path\": [\r\n                            \"fullName\",\r\n                            0,\r\n                            \"language\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"male_gender\",\r\n                         \"full_name_eng\"\r\n                    ],\r\n                    [\r\n                        \"full_name_eng\"\r\n                    ]\r\n                ]\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"mosip_verifiable_credential_id\"\r\n                    ],\r\n                    [\r\n                        \"student_id_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -1081,1676 +1081,12 @@
                   "urlencoded": [
                     {
                       "key": "vp_token",
-                      "value": "{\"student_id_credential_query\":[\"eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiIsIng1YyI6WyJNSUlCNVRDQ0FZdWdBd0lCQWdJUUdVZEYwa0JpUUdEYXdwKzBkQlNTNWpBS0JnZ3Foa2pPUFFRREFqQWRNUTR3REFZRFZRUURFd1ZCYm1sdGJ6RUxNQWtHQTFVRUJoTUNUa3d3SGhjTk1qVXdOREV5TVRReU16TXdXaGNOTWpZd05UQXlNVFF5TXpNd1dqQWhNUkl3RUFZRFZRUURFd2xqY21Wa2J5QmtZM014Q3pBSkJnTlZCQVlUQWs1TU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRUZYVk5BMGxhYSs1UDJuazVQSkZvdjh4aEJGTno1VU9KQklWc3lrMFNLU2ZxVGZLTUI2UitjRkROaWpkbUJZeXVFYVVnTWd1VWM4aE9Wbm5yZVc5dGhLT0JxRENCcFRBZEJnTlZIUTRFRmdRVVlSOHZGUVRsa2pmMS9ObktlWnh2WTBaejNhQXdEZ1lEVlIwUEFRSC9CQVFEQWdlQU1CVUdBMVVkSlFFQi93UUxNQWtHQnlpQmpGMEZBUUl3SHdZRFZSMGpCQmd3Rm9BVUw5OHdhTll2OVFueElIYjVDRmd4anZaVXRVc3dJUVlEVlIwU0JCb3dHSVlXYUhSMGNITTZMeTltZFc1clpTNWhibWx0Ynk1cFpEQVpCZ05WSFJFRUVqQVFnZzVtZFc1clpTNWhibWx0Ynk1cFpEQUtCZ2dxaGtqT1BRUURBZ05JQURCRkFpQkJ3ZFMvY0ZCczNhd3RmUDlHRlZrZ1NPSVRRZFBCTUxoc0pCeWpnN2wyTFFJaEFQUUpXeTdxUXNmcTJHcmRwY0dYSHJEVkswdy9YblBGMlhBVDZyVFg4dUNQIiwiTUlJQnp6Q0NBWFdnQXdJQkFnSVFWd0FGb2xXUWltOTRnbXlDaWMzYkNUQUtCZ2dxaGtqT1BRUURBakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d0hoY05NalF3TlRBeU1UUXlNek13V2hjTk1qZ3dOVEF5TVRReU16TXdXakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFRQy9ZeUJwY1JRWDhaWHBIZnJhMVROZFNiUzdxemdIWUhKM21zYklyOFRKTFBOWkk4VWw4ekpsRmRRVklWbHM1KzVDbENiTitKOUZVdmhQR3M0QXpBK280R1dNSUdUTUIwR0ExVWREZ1FXQkJRdjN6Qm8xaS8xQ2ZFZ2R2a0lXREdPOWxTMVN6QU9CZ05WSFE4QkFmOEVCQU1DQVFZd0lRWURWUjBTQkJvd0dJWVdhSFIwY0hNNkx5OW1kVzVyWlM1aGJtbHRieTVwWkRBU0JnTlZIUk1CQWY4RUNEQUdBUUgvQWdFQU1Dc0dBMVVkSHdRa01DSXdJS0Flb0J5R0dtaDBkSEJ6T2k4dlpuVnVhMlV1WVc1cGJXOHVhV1F2WTNKc01Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ1RnODBBbXFWSEpMYVp0MnV1aEF0UHFLSVhhZlAyZ2h0ZDlPQ21kRDUxWndJZ0t2VmtyZ1RZbHhTUkFibUtZNk1sa0g4bU0zU05jbkVKazlmR1Z3SkcrKzA9Il19.eyJjcmVkZW50aWFsX3R5cGUiOiJNU0lTRE4iLCJuYmYiOjE3NTI5ODQ3MzcsImV4cCI6MTc4NTM4NDczNywidmN0IjoiZXUuZXVyb3BhLmVjLmV1ZGkubXNpc2RuLjEiLCJjbmYiOnsia2lkIjoiZGlkOmp3azpleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TWpVMklpd2llQ0k2SWxKUk5XSkRiMngzUkZKV1pHUjRhbkk1TFUweUxVNUtPRVZ1TjFwSE1tTXpVbkZzVTJKVVR6TlJUMFVpTENKNUlqb2lZVlpFVVZkak5TMUJZbmhIYmxoV2JYRk1WMkphWmpGR1ZsWjFOVEF5TW0xaGFHdHpSVTh3VTJSZmR5SXNJblZ6WlNJNkluTnBaeUo5IzAifSwiaXNzIjoiaHR0cHM6Ly9mdW5rZS5hbmltby5pZCIsImlhdCI6MTc1Mzk0MjUyNywiX3NkIjpbIjI5SXE0b29UNzhGMkI1bFI1RzhGSGhGWWJKWmlER29vRHEySUpicFpCVG8iLCIzZVNTOEtZcUZzQVVHZVhIVWhwU21qd1k2TG5XaVJCMTVXYXRLY0ZTNzhJIiwiNE9mZGdDalZPUTJMbzhESXpTUEpodVVWT25yWGhjX1dkTGpCZDcwRGJFUSIsIkFwMWVweTdtVThiRkdrNXZkWXdlMjZma2pUY2taaW1uMDlncFlSR25XY3ciLCJEU0NWZHY3WklSOEZNNTR4c05MVlZqYndJc0JjcE9EUllHRTlCOTFra19RIiwiRnMwbGVHT0VMUU85ejhYblZsbVJTdXRUX0d3dDRTOWNubUJLcDF4TnRyQSIsIlFTbjl3dUx3LUJKY3VLRF9URHl0NGcyZlR4LU1KcmNyVzM0bVpKdHhtc0kiLCJfZDkyZVNKcW9FemdhQlctcFU2NUY2N3FOUno2Y2owRkJObDJYcTFmRWdFIiwia3VwOXhVUjZYMDZ5X3RiVVBPTzJ4VWxiWHJReG1qalRiVE9zMktYUUM4YyIsInBIYmh1eWxJbkZnaGtPY3hqcHVKb0o0S0hITUhfT2JSOWxYX0ZUa2Vmb2ciLCJ4YW1wZmJkRHJfd05LUllKN1F6NlAxZEZJcGJvMTJFdHRfZkMzYko4MDFvIl0sIl9zZF9hbGciOiJzaGEtMjU2In0.pf3MHMEAma64_-8mfmPdLCNzgzz5K0_EianTPd5IUzMlkXhB1v4NtQmRiARlLvTd9kkUChhW4lascAkW8TOnSA~WyI4NzY3MzA2NTE3OTE1MTMzMTI2NDI5MTUiLCJwaG9uZV9udW1iZXIiLCI0OTE1MTEyMzQ1NjciXQ~WyIyNzgzODk0ODU5Mjc2ODY0NTY1NjkxNzUiLCJyZWdpc3RlcmVkX2ZhbWlseV9uYW1lIiwiTXVzdGVybWFuIl0~WyI5Njk4OTYzODY5MDAwMTE3MzM0MTE0NDQiLCJyZWdpc3RlcmVkX2dpdmVuX25hbWUiLCJKb2huIE1pY2hhZWwiXQ~WyIxMDE3NzAzNzY5OTU2Mzc0MjI4NTIwMDQ4IiwiY29udHJhY3Rfb3duZXIiLHRydWVd~WyIxMTcwMTg2ODQ0MTkyNTczMzQyOTYyNDg5IiwiZW5kX3VzZXIiLGZhbHNlXQ~WyI0MzI1MjkxNDE2MzczOTU0MzgxNDM5NTUiLCJtb2JpbGVfb3BlcmF0b3IiLCJUZWxla29tX0RFIl0~WyI2ODA1NjkyNDQ3MTA1NjQ3ODc1ODQxNzUiLCJpc3N1aW5nX29yZ2FuaXphdGlvbiIsIlRlbE9yZyJd~WyI5MzE5ODU3NzkxNTk0Njc0ODE2NTg4ODciLCJ2ZXJpZmljYXRpb25fZGF0ZSIsIjIwMjMtMDgtMjUiXQ~WyI2MTkxMTk5NjI3Mzg2MDQ5MjI4ODkwMjEiLCJ2ZXJpZmljYXRpb25fbWV0aG9kX2luZm9ybWF0aW9uIiwiTnVtYmVyVmVyaWZ5Il0~WyIzNzM2NzUzNDQwNDA1ODI4Mzc2MTE0MjQiLCJpc3N1YW5jZV9kYXRlIiwiMjAyNS0wNy0yMFQwNDoxMjoxNy4wODlaIl0~WyI1NjU0NDMyNzk2MjEwMjQ2ODk0NjQ3MDgiLCJleHBpcnlfZGF0ZSIsIjIwMjYtMDctMzBUMDQ6MTI6MTcuMDg5WiJd~\"]}",
+                      "value": "{\n  \"mosip_verifiable_credential_id\": [\n    {\n      \"@context\": [\n        \"https://www.w3.org/2018/credentials/v1\",\n        \"https://w3id.org/security/suites/jws-2020/v1\"\n      ],\n      \"id\": \"urn:uuid:2341a08c-b520-4e0f-8d8c-efdb069da244\",\n      \"type\": [\n        \"VerifiablePresentation\"\n      ],\n      \"verifiableCredential\": [\n        {\n          \"credentialSubject\": {\n            \"claim169\": {\n              \"identityQRCode\": \"NCF4:ODGDE%SY0I37MMC2Y48%7HZ6UQ GNR3/ZBAX7L*69 U5L6+L8SEH $2F0141KX8Q%7R9+C9 H509::FNYPD2D4FE8CQB3VD:I81FP8SDVJ$%R0YD5D7$VN:29N$DZ+30/T2ZDP%CEU3VDU17SL8QUSC5XQU8NY6P:4RNMR-+I41AKTMB6OCLMRL3W1E$AQ:XLSHI3EMYWFI%LZ8FV7PYVINKOO6PU+VVY6W079.HUEVPFL0FRN5MAHP29TL.79URQ7FK3WO9M:$C3ZV V7ZCQ7.D9MU*GM%8TD3QK5KI5C$GPSAJR8KM.HDFB5LPG07M27BHE1MGD4N0JO2XMA8J5QR5NRK4G:DSS.L5T78NKG2H9$V$N7/YMK*0HEHGTEXDNNDF-MQMEHU/JXOBICJ.VF.SUS$P$AREEV-9TDQF$F2DFBSH8R-C5K1N+E1AM1UFRBQHRN0639O3KUCQD3$SE.*9W 7ADHSXBHHV0 P/P9+ V$H83X0-JUKY7U8UPCWRN5QF4UADAH2-6RJ+945T4TUL5UHA7D7N$0QMNADESRYMVWNE7K*V7YMR8:MLHQNJN  V+PVJGCI1WH.N+3F-$2:32:.B2P4RT7W04. KP40MZIKYLW2K.G3RUUD-VF0OLPTYDRH9OOWB0UC3J4U*SR0BT9O:9C6VJXLT$OJKIFR24./SZ8Q:9U.MC3B1U*EHDT0CAMHUH*P/GVLTRX$H%WSCGBH$UAM8*4VV*8U7V*.1TPFOBVCDKBEGD33$Y0WL3QASDKJ3 BTN4VEVFSO%Y74 F6%4UL1.R6B5N598LI00.2K327-0Z$Q4UIWH0LD6OU4-52GWO8YLYR0DJJ2GNHSMBR9S*P%BAU51FQGD7C5111XGXC9%GU1C19NGO%C9F0%*BA$0M8BJKN:MF0TQMGTT.TX D971EQ69ZCQIV/99L/TXLD%W4 8LA:O.WANZ2R8B+HBPC0ZG2G*OJ2TM.0C1U+HJ7TH.SE/5USA45692DDOVMC5HGTQ%AH65P2*2O/O1IS:8EZDR-HHY4G9RV94I-AW*38S4DHEB*SCGZO2DSC%T5WT*DSAXBZ705EHQOSFZBIAAD/089295OH%9Q F6%23S69QL1T7+DPQGVTVO7N7TWSBGB9740T09.9PYKO7GGKTNDC3CBJMLH8T3U71LLUAMCGNLMGLNHB:CZL4F+55/8SDJ4W27R26XHLZ43DAMCL9357$VSDKQRN6K6FE9X:D3VI2:5ZUC30BFGCSYO2.2DWFM1O7+TI4CGZL25WK29E8S/RJLJ147CQT1RGG:D5RPN5I5E3FC/GM63AP2+ERI K4W8N-J$-8B+JG9HL%Q Q7$TRC6A*X2KGPUA4%BMJYN*147MRHGQSPUU8KPMM8ESB+QXEGVICMWKKCB BNG/AZAA/NUQP0BT8B.O:0UAJM.LNTQ1QHG %N/0CD3TBF2T8V1T06R6WGM:ECGNMZ5VO*2-$NNSFL3CIOLR7IQVL1JS1P2AHG0ZL2%OH087ZOT6AX8WGZHADIMVBSUN113RK2Z19QYMUT7+IEDW5XA3+PS/AFSTRI*IB%IHYTH0HJM7JRH8IIT$G77WVA0DZG1WH9%OILG0OJ/-G C3-IL3VI*356RD*E4O+9Y/77YRK789PM7NN-671D3MYP3M0$XFZ4RNH5+IE5 LUVE5IDQOF/%D0HEYJF-/U-264QNJ32AD7659244G/09+K:WONC98RBBXKDLUY71UORY%SEQR*DOS21JLV8$CH-4KMUP6E170:F8T.Q4004:906BRQ3+CSQXSWDOJ:HSR69%9 S29D1ZBLRJ46FN1.Q6-C.O572EZUDL$S.CJ996:MJTFTHIHI2BDC3G%AN6GJ01.JC/5PMJ8+ MU:FZYNBS7Y9NM 4U0V74MO5W58JQG1BL3YQS2YTLZ7481C7EOP89KDH0R5%VH+3J7R9GJXKH%U0TJOHX4CQT/M4QSK5BGU-VDCAAUB47J /QYGD%8WOAFXA5--AS*GTYL4ZO- LGRLZS8WXAPS5P3UR6LALCPH8$C156K8/SP.QQJEO*LKBJ+HK%TDB21:PVB5O*RS6Q0YMI7C3ERI412GMFI5ES4TSLSSH7 ELA.VZF82USDW2W4O*/D13WC:KD4LY1J6CKM-QHSJWILQ0H%FT.U33AQU.2538Q78*/R5B4WDHEB4ZLJEHT21TP311V0G O:*K9%00A5TEQYCD1 3R0O YTFYK9F7QFO2QL$0N/5LDDU4X65E58:0XN1I7INE5A%JPTLWOVS5VWOTGHL6Z7C*B*KMW4DCYP-H3YYIXP10FM4NLROJNK8RA2X/QDP9QTA5IPJ62HVEOHJRW20CG8D4I34XUC7CTTTOJNHCF756V0J6LC149C*0BX$KBZ4:OBLL4DFH2XLH%M088YR5X7U4R8HS4TGO/CAPPKF211GHQD2R3VP24H8W: LRK7*DO6.QN*I+92UNAZRLFU0ARO:UL4GIHKKOITUI6V*Q%LT54PRERO1U%ME% FKYMGVHQSKYEMGF57UCUTLUV03-8IP3TT8.BLJ27QQFP6H2W0VNFU/FE4HQVGA.V616DUFY%0O5HCMK/MHGQ6+0QJHG.BNIPL$-2PA7S*I.-JQZO/-832IT:O2:AGIKU8GA/Q7TBSXUIHEBTT:TI9ADL%R9+G:KDSZM.7L%NOFJNJ1RSINW+E300F.TRQ8SE8V6M.F9B/TWB4%+9/PRKX22HQX 6N%R6.4L3P8US09AKG9+J6XT0Q94XLV%65+BK+BDFGKDFPB-J6FHV0MT*EQ%81$SWRHSKLMP282S2XPE*L KG9HH+$JW8HO.AO26 W1X7QLYT4OTW5U1FB-NDB:Q6LFUHUT GWJR2M1M%2QLND71U.DU:SS0RCG54CAHG4CO9E*PLU1Y*O%:BG+167FTUFAQQ6DB2TF0S1E%1$88%JOEE3+D9ZDOCKBI-DW18B03S/IH0LAJJRKTC88M KRVEJI6PHC+ 50JH$*I6-A41PQV2+0E*-D%:10*QC:1XB310H0KD0WIE83/X9EOG9BMZJ3BKQ 6B XVNJC87K4QSZW2E/5*M6YU5/.VKGHXJQXVI0JJ9LBBLHM3W:D8-N38XI$ EN656IDI1JB8KIHRCVVR/MLXIA7GY21AA9/%8XELV:AA5E9E22/L3LCXT8/HRYY2Z$K*:1TGT8L6-VC9XO*I508GJ11O.77V4GYF1 2UZFZ53DTVNGEG6D3XQ6QD-U6RVNS:53FVS7V409-4T10DK2W1%CEK8R5PGQRX 33H8D*58 AFY644IR*CJAW+A8G3PEBU N3/XFUUQI%BX27M T- VP-F.+3LWOHTFID6W$S1WNXPGSIF06F1ZV:N08G6\"\n            },\n            \"gender\": [\n              {\n                \"value\": \"MLE\",\n                \"language\": \"eng\"\n              },\n              {\n                \"value\": \"MLE\",\n                \"language\": \"hin\"\n              },\n              {\n                \"value\": \"MLE\",\n                \"language\": \"fra\"\n              }\n            ],\n            \"phone\": \"7367102638\",\n            \"dateOfBirth\": \"1992/04/15\",\n            \"UIN\": \"3920190347\",\n            \"id\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ==\",\n            \"email\": \"IdRepository_AddIdentity_AuthStatus_Vid_Valid_smoke_Pos@mosip.net\",\n            \"fullName\": [\n              {\n                \"value\": \"TEST_FULLNAMEeng\",\n                \"language\": \"eng\"\n              },\n              {\n                \"value\": \"TEST_FULLNAMEhin\",\n                \"language\": \"hin\"\n              },\n              {\n                \"value\": \"TEST_FULLNAMEfra\",\n                \"language\": \"fra\"\n              }\n            ],\n            \"compressedFace\": \"data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABQADwDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCEF3607G2stH1OT/Vxk/nU8VtrEkoVouvvWftYL4dRvnm/eZLJe+VLtzUi6gAMlqzNYs5rNWkmeJHH8JcZ/KuZTxLFbyAXS5i7lRk1aqXV0hOKW7O4/tUBsbqka4nmXMQzVTw/rfgvVWWAyzLct08yHC/nmvSLPw5YJa77cxyD+8hBH6VPvt3Wg1Y84e21SXhIifzpn9la3/zw/U16jFarB0qxvqr1OrFd9Dm4LR4vuLUOv38mkaLJeKcTAhV+prei2jrWJ44svtvh5UjGT9piLf7ueaq/NLUOljltD8MN40xqeqqfNPtnrWZ4v8D2NhcPHbrzzj5a6iTxbZ+GVNpbTYQfhWDe+K7fVp/PeXND5ErdTSKs1oeeSaK1vEcAq4rtPht41utN1aLRbyUi1dSBk/xdB/Os3Vb+1ZyUfNc3DBNPr9lcQLnFxHz/AMCFZxbT12KnCL1R9TLCWO1xzUn2H2ojM33pRiSpvOuPT9a0uYcyMmKGL+Osm/Mr6mLYD/RDnJq75+/vVO+ult4yzNgVME27FxaTbZxPjDwDb3908tlJ8/OA2APzrOg8BDT/AArJNdKn2pcY2EMOh71vXetlrjyy+Iz1NYWuazqkVs8VnLEbPvmUA/lWslFdDSNmjh10ySX7y1s6DCtnqtqk3yxiRSPrkYqrZ6jI2Nxrp9B0r+29ThTbu2kSfkc1zt6WJkktT3COdrgCVutTeZVW2+S3xTt1U2cyi7s5m1dWAya868c+JJ7bX49Ojb90clhnuDXoaCG2/wBYcYrx/wCIUcbeIxdxHI3FQfcmrj7zsi5STi13NON4rpME5kPasvUrLywQUGavzWEtroFrewL/AKV5eX+tcy+sajcRk3Iw/wBaTbta5rGTtdiwosbgNwK9a+Flq6pdX5H3TsjP+yRzXibXU7P83T612/w+8f8A9nSy6TdyMkbOBGewA459KiEfesObUonuplCrgGovO96pQahaXAxFOkme6MCKs7Upqxje54xc+Lb67J+bOfeub1OeW8mUT/dVw34g0WPQUuo969ZcvI0lucNNtvU7XT5Jb7SNw5Q45rl9YsljdiBXe+BLWOfwt83t/I0mp6DaSbsj9K5J0bu6PSjLQ8dnO3NZs0u5sE8V0/iYaZp872yl/P7YTj8649ySeaz9mkiJTurG3pPiHVNHkU2d7KsS/wDLMHANdR/wtTW/Qf8AfZrgYvuVJR7R9Dmluf/Z\",\n            \"face\": \"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\"\n          },\n          \"proof\": {\n            \"proofValue\": \"z534RdN9XUQGLFHszC4MnN4f5PfKYcCq2Cjtbb8MH2nQe1x2kcL4Q9NhqGUAr4MgjFSfFWsgozGeVAkKsEg4RcF5N\",\n            \"type\": \"Ed25519Signature2020\",\n            \"created\": \"2026-06-15T14:11:31Z\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"verificationMethod\": \"did:web:inji.github.io:inji-config:dev-int-inji:mosipid-identity#7TmkqqmmpxilQ_H54iWD1Uea90JTiup_p9mUi90UMvA\"\n          },\n          \"type\": [\n            \"VerifiableCredential\",\n            \"MOSIPVerifiableCredential\"\n          ],\n          \"issuanceDate\": \"2026-06-15T14:11:31.180Z\",\n          \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://inji.github.io/inji-config/contexts/mosip-identity-context.json\",\n            \"https://w3id.org/security/suites/ed25519-2020/v1\"\n          ],\n          \"id\": \"https://mosip.io/credential/b7b92027-1368-4bc3-b69d-e0b88ccfd7f6\",\n          \"issuer\": \"did:web:injicertify-mosipid.dev-int-inji.mosip.net\",\n          \"expirationDate\": \"2028-06-14T14:11:31.180Z\"\n        }\n      ],\n      \"proof\": {\n        \"domain\": \"injiverify.dev-int-inji.mosip.net/\",\n        \"verificationMethod\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ#0\",\n        \"type\": \"JsonWebSignature2020\",\n        \"jws\": \"eyJjcml0IjpbImI2NCJdLCJiNjQiOmZhbHNlLCJhbGciOiJFZERTQSJ9..mjJcr8FMjUnuDZ8GGIeC3WRS7WRiP1ne_8HAx4AfozAZHHabLZs_lFiSzLozo1MS8MhjSXWJVnOUego5RiMxDw\",\n        \"challenge\": \"NkdHJkBIbdOdQaAjWm8gpA\"\n      },\n      \"holder\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ#0\"\n    }\n  ]\n}",
                       "type": "text"
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForOpenID4VP}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "vp-result",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results v2",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-results",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "1.9. sd-jwt - expired - dcql request",
-          "item": [
-            {
-              "name": "vp request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"MTc3OTEwMTI1ODkzOQ==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"dc+sd-jwt\",\r\n                \"require_cryptographic_holder_binding\": false,\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"TestCredential_SD_JWT\"\r\n                    ]\r\n                }\r\n            }\r\n        ]    \r\n    }        \r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp submission expired",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"student_id_credential_query\":[\"eyJhbGciOiJFUzI1NiIsInR5cCI6InZjK3NkLWp3dCIsIng1YyI6WyJNSUlCSkRDQnlxQURBZ0VDQWhSNE5xOStNUjVyTFZFS242U1FSd0daRHh3SWpUQUtCZ2dxaGtqT1BRUURBakFTTVJBd0RnWURWUVFEREFkRlExOVVaWE4wTUI0WERUSTFNRGt3TXpFd01qVXhPVm9YRFRJMU1Ea3dNekV3TWpreE9Wb3dFakVRTUE0R0ExVUVBd3dIUlVOZlZHVnpkREJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUFCTXJvelh2R2tuZm5SRnFDMG8vcWRwK3Zpd1lvT2drVmRRZkpuWFZMMlJjYUFHL0dOSEVYMkxPVWxJY3JtVDZNS1o4WkhFWXdWMU9tUTB5OUNOd0ViRlF3Q2dZSUtvWkl6ajBFQXdJRFNRQXdSZ0loQU9VSjkvTXdJUGVvYnJMRERhT2pLQkVuSDJoTjVTekY4dnRmOTBVZTY5NHJBaUVBeFFXeGo5dUt1MlliK2pDYk03a0lxaFcrNkNVYWk5WGNLWG9MdFNwanJEYz0iXX0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTY5MDAwMDAwMCwiaWQiOiIxMjM0IiwidmN0IjoiVGVzdENyZWRlbnRpYWxfU0RfSldUIiwiX3NkIjpbImJEVFJ2bTUtWW4tSEc3Y3FwVlI1T1ZSSVhzU2FCazU3SmdpT3FfajFWSTQiLCJldDNVZlJ5bHdWcmZYZFBLemc3OWhjakQxSXR6b1E5b0JvWFJHdE1vc0ZrIiwieldmWk5TMTlBdGJSU1RibzdzSlJuMEJaUXZXUmRjaG9DN1VaYWJGcmpZOCJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vaXNzdWVyLmV4YW1wbGUuY29tIiwibmJmIjoxNjkwMDAzNjAwLCJleHAiOjE2OTAwODAwMDB9.P5tm14I5pja6G0spZQ07HbYBZwGZCeNH86VqyfRrWYgZrx5fv75ndJdiCEV-Mvj84p8ZWLFgeY5uPoS_ypT17A~\"]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqIdForOpenID4VP}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "vp-result",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results v2",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-results",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "1.4. ldp_vp - expired - require_cryptographic_holder_binding false",
-          "item": [
-            {
-              "name": "vp request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"MTc3OTEwMTI1ODkzOQ==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n            \"credentials\": [\r\n            {\r\n                \"id\": \"age_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false,\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"male_gender\",\r\n                        \"path\": [\r\n                            \"gender\",\r\n                            null,\r\n                            \"value\"\r\n                        ],\r\n                        \"values\": [\"MLE\"]\r\n                    },\r\n                    {\r\n                        \"id\": \"full_name_eng\",\r\n                        \"path\": [\r\n                            \"fullName\",\r\n                            0,\r\n                            \"language\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"male_gender\",\r\n                         \"full_name_eng\"\r\n                    ],\r\n                    [\r\n                        \"full_name_eng\"\r\n                    ]\r\n                ]\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"age_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp submission expired",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"age_credential_query\":[{\"issuanceDate\":\"2026-03-27T10:34:33.914Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"language\":\"eng\",\"value\":\"MLE\"},{\"language\":\"hin\",\"value\":\"MLE\"},{\"language\":\"fra\",\"value\":\"MLE\"}],\"compressedFace\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABQADwDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCEF3607G2stH1OT/Vxk/nU8VtrEkoVouvvWftYL4dRvnm/eZLJe+VLtzUi6gAMlqzNYs5rNWkmeJHH8JcZ/KuZTxLFbyAXS5i7lRk1aqXV0hOKW7O4/tUBsbqka4nmXMQzVTw/rfgvVWWAyzLct08yHC/nmvSLPw5YJa77cxyD+8hBH6VPvt3Wg1Y84e21SXhIifzpn9la3/zw/U16jFarB0qxvqr1OrFd9Dm4LR4vuLUOv38mkaLJeKcTAhV+prei2jrWJ44svtvh5UjGT9piLf7ueaq/NLUOljltD8MN40xqeqqfNPtnrWZ4v8D2NhcPHbrzzj5a6iTxbZ+GVNpbTYQfhWDe+K7fVp/PeXND5ErdTSKs1oeeSaK1vEcAq4rtPht41utN1aLRbyUi1dSBk/xdB/Os3Vb+1ZyUfNc3DBNPr9lcQLnFxHz/AMCFZxbT12KnCL1R9TLCWO1xzUn2H2ojM33pRiSpvOuPT9a0uYcyMmKGL+Osm/Mr6mLYD/RDnJq75+/vVO+ult4yzNgVME27FxaTbZxPjDwDb3908tlJ8/OA2APzrOg8BDT/AArJNdKn2pcY2EMOh71vXetlrjyy+Iz1NYWuazqkVs8VnLEbPvmUA/lWslFdDSNmjh10ySX7y1s6DCtnqtqk3yxiRSPrkYqrZ6jI2Nxrp9B0r+29ThTbu2kSfkc1zt6WJkktT3COdrgCVutTeZVW2+S3xTt1U2cyi7s5m1dWAya868c+JJ7bX49Ojb90clhnuDXoaCG2/wBYcYrx/wCIUcbeIxdxHI3FQfcmrj7zsi5STi13NON4rpME5kPasvUrLywQUGavzWEtroFrewL/AKV5eX+tcy+sajcRk3Iw/wBaTbta5rGTtdiwosbgNwK9a+Flq6pdX5H3TsjP+yRzXibXU7P83T612/w+8f8A9nSy6TdyMkbOBGewA459KiEfesObUonuplCrgGovO96pQahaXAxFOkme6MCKs7Upqxje54xc+Lb67J+bOfeub1OeW8mUT/dVw34g0WPQUuo969ZcvI0lucNNtvU7XT5Jb7SNw5Q45rl9YsljdiBXe+BLWOfwt83t/I0mp6DaSbsj9K5J0bu6PSjLQ8dnO3NZs0u5sE8V0/iYaZp872yl/P7YTj8649ySeaz9mkiJTurG3pPiHVNHkU2d7KsS/wDLMHANdR/wtTW/Qf8AfZrgYvuVJR7R9Dmluf/Z\",\"phone\":\"7367102638\",\"fullName\":[{\"language\":\"eng\",\"value\":\"TEST_FULLNAMEeng\"},{\"language\":\"hin\",\"value\":\"TEST_FULLNAMEhin\"},{\"language\":\"fra\",\"value\":\"TEST_FULLNAMEfra\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0=\",\"UIN\":\"3920190347\",\"claim169\":{\"identityQRCode\":\"NCF4:OWBBPP3F:H37MMC2Y48.6H-2S6612S3T3MC 3QM3+NV/-KCFI3IO-THZL0PXMYHFEPJ1$LOOQ8HP7CU*GBEWH55MRNRO.7-MEV2ITVNSRE:XRO:TT7LMFV*ITX/L WOU-JL0QKXDH S02S4O3YNVF%PIQJ/4NN873KFOM3-NEUEDV0FC:6//EW S4+DNC7M.Q*IET7VN06D+MO4A*9F4SUBCFEJVHAO 8TF7TMKIG.F5W6CZR6JN.5G6ZUSDSQ:1V SIBS7*JXYPH02YJMH-9KZUJ8MM:T87K0AV+W9ZSV%0N7CPK U6A6-OD$QVW8TW4T*3QBKUXEF4IV.5N5SM08B6JPS3WHUVH6EB.SKJ23F6/8SS5S2ZKJB6N:91BJTBPLPP%BH1Y98JTTDS8SO7WSKLIUSC+RNZXNWW7SKR9PI/%PVT28P6NEB1XLN/FM5S86GG2RE.O-7S0/40UQKCJB0F-NTK+8S5T68PHLC87B:KUV L1HB0U6:PE4SJB1VA1R4ZLO33V+LI4N2NMHUI8QIIMJ/DA +PK%95$UI7QU38C5P8YT5/3C2GXWCRF6-3EYDR4PDTHE+TE$3BDHRY$I*.3%HKCT4:F0A$SNC6XQ5AP6425ZNHGTLZ:LKM530C-IF8EVPEW6144+5LYH418P0S:APHF4XWTIIE:$H5KD*A7-+8Z/P 1QZPGJ+F91F 3UY4EWV1443%N53YH9CEM5P*9AMBV9GVTZH7YGPAI:*ST%RGSPT.1TJC7R0PUIA7PRWS4+AF5FR2RYXUTXMNYEE14Z6OL2RB-5D9JI+65KVW7QAX1RQ1L48W:EOTC%HT.GKP92:ESK+800W551 YFLW1.V3LRRO4PMKFZ48LVHXSKNERX*UKLEV/4J36 P4XQIQBCME4:9BJG1A 63THA$3S2CF:4$NAAAD$HMTZS5ASOMH91ATL75CA2Y958VMH4KCG7J6%F8/DLI35V 3I5JTEO.28/WG0*P-TKF8RA823F4LK0L%H4T6I0KIO1B.8U8F25WG18IUIX6W9:VTO6MDW5:V/5CFIM8O55HAZXVE2G:*7SCWK5BI0D:OQ GUEXKC7F1RP.JEJHS3DF-V2*OGWVLW664A5 0P/JPS2J++14/8:EH3CQ%QU$A8CFPMQSQ$78K3.7QVRC9E2U ECFVMB8-%F.Z6PYB7Q3V PJRJNKO-844USZYG*EMMEO$TC*80.F6Q$FEPTZAW.0Q2 8D70APMYTI$$O3CB.VLSE6GNBO0FBGMUWKH:RSAL$MI2:KR.3TWVD3JLZLZAL1PBMESI%RFB2/$F9OSLWSUWBOJV$41P/HO.Q$MCUZNUH2P*UT-U$0E2LL 0IGPKS46: 5UA422SJ3T*GOE4P*.B68G8*Q.3U66RB4UWQ7GSL7%AHPJHX25RPIUVU.4SGVLIC2*59BRO 7$ZAOCOJV7RY11ON/AQ0406AT%GQGMR1+MNRE+W1PCSU7551Q RAFH8YY74$OUXAX8LLCOX NBV4$/8AJP2+6EJ5U1A+XGQ%LIMCC-H6890AHOF1W1RAKMPRGKNQZFUV3A0WK4.89YFN%R64HYWA*FGKVB/XKCZE4-2H113R4Y QB.F6$JCP3OZGPFR3+GQ OLLR UQX81SPHUIGK:KJQNG/KAX1TLMN45M/HT51%XP4-AN91HRGE/MPQFXN4EWPGRERZR$K0P07BNP.X5TACJGITNOCKQ$GVQV5+$4DI4FHAR$CP2DP76R*9S5D*/JV*87KVU9S.SL:DAO.0/J5VES*QNY%9O44MOH2PHU98 Y0J-38$1KU8XGH8J8/22BFRU F9LMO:O%-DSM78GF2ZV6XUD8JPYHOKK/YL0:58$KPNF.54DTO7TL$ES%ODC-DZPL+Y2TM1P*C$A6A J*VQJ*FSRD+6GGY43TO+4P5870LF*9Q.F8UWB29A2NJV 615O%/0C%EA*48NKW70-46.HHMVV$992BLZ24Y8OI Q$CR%+KO$E5TRO7O+-BGF1PV2XKS-J51LUMVLBF5*KQY-Q:RHIYNTJLPHRPCI2OG.AT2NVT%EA%RWJ591L67DWI3ILGU-7E16DCNH90.YK 2HE$S*$O%:BNQB3FF-AFEZ19RTA6G5CI467B:O8162XRY08MC5MKLN*K9BLA-E0%4RTT KS ONQBPC$UF-GN-1I7A 3FG11COKF89R3T0H74A7TH8F60NA6UNTHKOQOPUVE5SRF-0BFU.RVNFD/1Q$AE%LDHZ5$GD:M7K:P9G1Z60OP88ZSSLHIDT2STR8WXX7NLFYNLO.1X6JTYDNGBTUUL*8G*K.TO8XD1H533L/FQI$OK:MPPQ:XAZF6G O.*J6%4EX8J44/59.499ORDE77EMGTSX0IK/NFV9VJGSAB*$I1JL$JHB7RVAH0MCBF58 D0229THYTN1JQ8B9U9EBVAWBLJLG%OKPS8E$FXFPF3GJRDA:H+469-MHW43+OB*Q1TT4D8ECEISTVYKY7D:UVMWH%X66I7RHM$%6P V/YJS0CHZ54J42BL9$LBC1+FB$F5JD8J72C3HQFIUQLGY1T7S2A4RHGY/B414EKS:BC$FW*Q933K5B0HJKXDLEMKNU1+UM.24Q*51J55U0P:HM C:5L$FEMA2%XSUGE4W2FBLYBK6:UPCRE+VGWB3OF:$S D3/7NPFCXHBY*D:JLS8EU.DG1VM.DJ*JCCOCYN+7AUEIQXT:LIXZVRGPWXQ36VV-OCWEN.PT275919GE*CN%*QKJA6U9RFGTEP%-F2H9AFTTF3-ETQKEEBTSOKFPD0.J3B2JHNFF43JDHY8PBNUG6UULZ34HQSA/4GKCPY2DK1HQ8RWM1H7ZMFYYVR7RLIB3*EG:JJWFBDCV4NJJ8*%GE2MQI8QOBFJNQ2V:H95ZIR996HAUUMKH0*GEL5BJP8CV3J7K ZM23J-:J8P83M8W7ALAE73PLLID6636R1N3N4AP+GM$C4ILP%4:E7322DHLBX3G*PPCJ6N90G42.KKZAVJM3:O+UJARBKUOR+EPN8G5PJJKMHB4+K-*8BPAUFKLXL.*8AUE /AZ+7LEJSCTCDNS$8BUH9 P1N9-08KJCK%MYZK43L6/AAJCSFW7FKZ*HRRPXNNYP2X*M2Q9K9Q9VD:+F/IBQJ9IFWY21AA9/%8XELV:AA5E9E22/L3LCXT8/HRYY2Z$K*:1TGT8L6-VC9XO*I508GJ11O.77V4GYF1 2UZFZ53DTVNGEG6D3XQ6QD-U6/VN0CRR*6-.MV1EC*3N28.-AD-F5:AI%G1ZR%+5+BP04F-9QUEJR0K-XHW5E-+37QNJEUKFVGUG86F6DU CVF*LPP9/N3IDKS68*8J6IJ$HQ:129F289KV7TW40E%6.4\"},\"email\":\"IdRepository_AddIdentity_AuthStatus_Vid_Valid_smoke_Pos@mosip.net\"},\"id\":\"https://mosip.io/credential/752bf960-c9d7-4bab-94bc-ca4af28016c2\",\"type\":[\"VerifiableCredential\",\"MOSIPVerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://inji.github.io/inji-config/contexts/mosip-identity-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuer\":\"did:web:inji.github.io:inji-config:dev-int-inji:mosipid-identity\",\"expirationDate\":\"2028-03-26T10:34:33.914Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2026-03-27T10:34:33Z\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:web:inji.github.io:inji-config:dev-int-inji:mosipid-identity#7TmkqqmmpxilQ_H54iWD1Uea90JTiup_p9mUi90UMvA\",\"proofValue\":\"z4jFVQRdQq5taLtmByFUxHDStQxbFefT9M964ZK6VFVKKPNa5cztzQKxMHBTDcEhS6mQMSnv4Vf2YBFcTvXBooqTR\"}}]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqIdForOpenID4VP}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "vp-result",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results v2",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-results",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "1.7. ldp_vp - status check error - require_cryptographic_holder_binding false",
-          "item": [
-            {
-              "name": "vp request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"MTc3OTEwMTI1ODkzOQ==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n           {\r\n                \"id\": \"age_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                        \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                        \"https://example.org/credentials#FarmerCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false\r\n            } \r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp submission status check error",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"age_credential_query\":[{\"credentialSubject\":{\"gender\":\"Male\",\"primaryCropType\":\"Maize\",\"mobileNumber\":\"9876543210\",\"postalCode\":\"453000\",\"landArea\":\"3 hectares\",\"fullName\":\"John Doe\",\"secondaryCropType\":\"Rice\",\"dateOfBirth\":\"25-05-1990\",\"face\":\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAFCAYAAABW1IzHAAAAHklEQVQokWNgGPaAkZHxPyMj439sYrSQo51PBgsAALa0ECF30JSdAAAAAElFTkSuQmCC\",\"farmerID\":\"987654321\",\"villageOrTown\":\"Koramangala\",\"district\":\"Bangalore\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6Iml3Qkl1Q2QzaFU1NlBWM3VTc3gzekhMc1E4SXdYckdHdmh6YkE1VlJuQkEiLCJhbGciOiJSUzI1NiIsIm4iOiJtMWlMQ0prNzA5VkpIbUF2MURsWUxsblA0UDEtLXFfU3Q3aVo3WjhWbXk0d0Mxb2FTQWxXdjFXZjlKQXg2YmQ3OXdMbDhINEkwa25GeG9FbkktTUhvOUtGRXpFcGdJNXZIUHY2X0M2dWI4RmUwaXphRVFXTlY3VEpVRG54MVZ5OU5UZS15ekFVd2dfWk91Y0pFb3hyQW54VXM5OFcyTWpyUmtZdHVQcTlKRUxVTzRJM0wxX1B5S21hRG8zN0xCR3NVamhLVmQ0X0VzTkVPQ3AwQTZwbnBaUUd1S1RteXVhMUVYSDhLWUVTSEZ4alA4NGVCaGk0YmZPSWMwQjQ2VlZrVG81WG9TeUtnRi1xemRyTGFQRGJwZGxBaVNKMEJ5Vk5jaUE3Z2ctWEJLQkV0QVd1b19EQ3pYZUsxREJKT2txMXlkWEJzeWdjeGtpVmdobnFtUTFsVHcifQ==\",\"state\":\"Karnataka\",\"landOwnershipType\":\"Owner\"},\"validUntil\":\"2027-10-09T03:08:19.711Z\",\"validFrom\":\"2025-10-09T03:08:19.711Z\",\"type\":[\"VerifiableCredential\",\"FarmerCredential\"],\"@context\":[\"https://www.w3.org/ns/credentials/v2\",\"https://piyush7034.github.io/my-files/farmer.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuer\":\"did:web:piyush7034.github.io:my-files:sample-ed25519\",\"credentialStatus\":{\"statusPurpose\":\"revocation\",\"statusListIndex\":\"7\",\"id\":\"http://localhost:8090/v1/certify/credentials/status-list/649d3d36-2719-42eb-9f00-ac479a906059#7\",\"type\":\"BitstringStatusListEntry\",\"statusListCredential\":\"http://localhost:8090/v1/certify/credentials/status-list/649d3d36-2719-42eb-9f00-ac479a906059\"},\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2025-10-08T21:38:19Z\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:web:piyush7034.github.io:my-files:sample-ed25519#LYs95rEHKsqm1_TIFJxffLUXHZL1rM_h-UuwRi6PtN4\",\"proofValue\":\"z5Z3Rj9rhV5b6whiq4EgZaD8gmtsBtfMEqwNXAgasCxtBRCpc35DkiGFyRfy8NYDtXBDX6RjAUpWfgNGn94t2ywgm\"}}]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqIdForOpenID4VP}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 500\", function () {",
-                      "    pm.response.to.have.status(500);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "vp-result",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results v2",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-results",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "1.6. ldp_vp - revoked - require_cryptographic_holder_binding false",
-          "item": [
-            {
-              "name": "vp request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"MTc3OTEwMTI1ODkzOQ==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"age_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                        \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                        \"https://example.org/credentials#MockVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false\r\n            }    \r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp submission status check revoked",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"age_credential_query\":[{\"credentialSubject\":{\"VID\":9876543210,\"gender\":[{\"language\":\"eng\",\"value\":\"Male\"},{\"language\":\"fra\",\"value\":\"M\u00e2le\"},{\"language\":\"ara\",\"value\":\"\u0630\u0643\u0631\"}],\"province\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"phone\":\"+919427357934\",\"postalCode\":45009,\"fullName\":[{\"language\":\"fra\",\"value\":\"Siddharth K Mansour\"},{\"language\":\"ara\",\"value\":\"\u062a\u062a\u06af\u0644\u062f\u0643\u0646\u0633\u064e\u0632\u0642\u0647\u0650\u0642\u0650\u0641\u0644 \u062f\u0633\u064a\u064a\u0633\u064a\u0643\u062f\u0643\u0646\u0648\u06a4\u0648\"},{\"language\":\"eng\",\"value\":\"Siddharth K Mansour\"}],\"dateOfBirth\":\"1987/11/25\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\",\"UIN\":9876543210,\"region\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"email\":\"siddhartha.km@gmail.com\"},\"validUntil\":\"2028-01-08T07:19:56.385Z\",\"validFrom\":\"2026-01-08T07:19:56.385Z\",\"id\":\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\",\"type\":[\"VerifiableCredential\",\"MockVerifiableCredential\"],\"@context\":[\"https://www.w3.org/ns/credentials/v2\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuer\":\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\",\"credentialStatus\":{\"statusPurpose\":\"revocation\",\"statusListIndex\":\"94010\",\"id\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\",\"type\":\"BitstringStatusListEntry\",\"statusListCredential\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\"},\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2026-01-08T07:19:56Z\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity#BF6EnRlmWN2x2T0HsTBbDtbci_dD2qYPdtxlVpv2Lz8\",\"proofValue\":\"z2jBgb8JmCH3b5LyfeqF1gFsgBTmQcr18hTD98SDGhoL3Nrr8vwjWw7iGxVECYz9yD5SWCrPP83YAQ81yH2WvDY1b\"}}]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqIdForOpenID4VP}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "vp-result",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results v2",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-results",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "1.5. ldp_vp - invalid signature - require_cryptographic_holder_binding false",
-          "item": [
-            {
-              "name": "vp request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"MTc3OTEwMTI1ODkzOQ==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"age_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"MockVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false,\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"male_gender\",\r\n                        \"path\": [\r\n                            \"gender\",\r\n                            null,\r\n                            \"value\"\r\n                        ],\r\n                        \"values\": [\r\n                            \"Male\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"full_name_eng\",\r\n                        \"path\": [\r\n                            \"fullName\",\r\n                             null,\r\n                            \"language\"\r\n                        ],\r\n                        \"values\": [\r\n                            \"eng\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"male_gender\",\r\n                        \"full_name_eng\"\r\n                    ],\r\n                    [\r\n                        \"full_name_eng\"\r\n                    ]\r\n                ]\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"age_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp submission invalid signature",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"age_credential_query\":[{\"credentialSubject\":{\"VID\":9876543210,\"gender\":[{\"language\":\"eng\",\"value\":\"Male\"},{\"language\":\"fra\",\"value\":\"M\u00e2le\"},{\"language\":\"ara\",\"value\":\"\u0630\u0643\u0631\"}],\"province\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"phone\":\"+919427357934\",\"postalCode\":45009,\"fullName\":[{\"language\":\"fra\",\"value\":\"Siddharth K Mansour\"},{\"language\":\"ara\",\"value\":\"\u062a\u062a\u06af\u0644\u062f\u0643\u0646\u0633\u064e\u0632\u0642\u0647\u0650\u0642\u0650\u0641\u0644 \u062f\u0633\u064a\u064a\u0633\u064a\u0643\u062f\u0643\u0646\u0648\u06a4\u0648\"},{\"language\":\"eng\",\"value\":\"Siddharth K Mansour\"}],\"dateOfBirth\":\"1987/11/25\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\",\"UIN\":9876543210,\"region\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"email\":\"siddhartha.km@gmail.com\"},\"validUntil\":\"2028-01-08T07:19:56.385Z\",\"validFrom\":\"2026-01-08T07:19:56.385Z\",\"id\":\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\",\"type\":[\"VerifiableCredential\",\"MockVerifiableCredential\"],\"@context\":[\"https://www.w3.org/ns/credentials/v2\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuer\":\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\",\"credentialStatus\":{\"statusPurpose\":\"revocation\",\"statusListIndex\":\"94010\",\"id\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\",\"type\":\"BitstringStatusListEntry\",\"statusListCredential\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\"},\"proof\":{\"verificationMethod\":\"did:web:mosip.github.io:inji-config:qa-inji1:landregistry#UHNnpAY2hEkSnXqkc3aS07EgTEaw9WC64kpO3jvP9X0\",\"created\":\"2025-11-24T07:37:30Z\",\"type\":\"Ed25519Signature2020\",\"proofPurpose\":\"assertionMethod\",\"proofValue\":\"z5gfKobfm77qMGgs41LDkoSjZdS7fTx19runRBxPSckQUfCxMgbmnF9SiGwgJrkuzx1yYqdvkfW7u69v5cMc3ePCp\"}}]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqIdForOpenID4VP}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "vp-result",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results v2",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-results",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "2.1. multiple vp submission - ldp_vp, sd_jwt - require_cryptographic_holder_binding false",
-          "item": [
-            {
-              "name": "vp request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"MTc3OTEwMTI1ODkzOQ==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"vc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"eu.europa.ec.eudi.msisdn.1\"\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false,\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"phone_number\",\r\n                        \"path\": [\r\n                            \"phone_number\"\r\n                        ]\r\n                    }\r\n                ]\r\n            },\r\n            {\r\n                \"id\": \"id_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"student_id_credential_query\",\r\n                        \"id_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "1 ldp_vc valid, 1 sd_jwt valid",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"id_credential_query\":[{\"issuanceDate\":\"2025-12-23T10:27:09.133Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"value\":\"MLE\",\"language\":\"eng\"}],\"city\":[{\"value\":\"TEST_CITYeng\",\"language\":\"eng\"}],\"phone\":\"2261640506\",\"fullName\":[{\"value\":\"TEST_FULLNAMEeng\",\"language\":\"eng\"}],\"addressLine1\":[{\"value\":\"TEST_ADDRESSLINE1eng\",\"language\":\"eng\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\"UIN\":\"2042351307\",\"email\":\"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"},\"proof\":{\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"https://api.released.mosip.net/.well-known/ida-public-key.json\",\"type\":\"RsaSignature2018\",\"created\":\"2025-12-23T10:27:09Z\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"},\"id\":\"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\"type\":[\"MOSIPVerifiableCredential\",\"VerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",{\"sec\":\"https://w3id.org/security#\"}],\"issuer\":\"https://api.released.mosip.net/.well-known/ida-controller.json\"}],\"student_id_credential_query\":[\"eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiIsIng1YyI6WyJNSUlCNVRDQ0FZdWdBd0lCQWdJUUdVZEYwa0JpUUdEYXdwKzBkQlNTNWpBS0JnZ3Foa2pPUFFRREFqQWRNUTR3REFZRFZRUURFd1ZCYm1sdGJ6RUxNQWtHQTFVRUJoTUNUa3d3SGhjTk1qVXdOREV5TVRReU16TXdXaGNOTWpZd05UQXlNVFF5TXpNd1dqQWhNUkl3RUFZRFZRUURFd2xqY21Wa2J5QmtZM014Q3pBSkJnTlZCQVlUQWs1TU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRUZYVk5BMGxhYSs1UDJuazVQSkZvdjh4aEJGTno1VU9KQklWc3lrMFNLU2ZxVGZLTUI2UitjRkROaWpkbUJZeXVFYVVnTWd1VWM4aE9Wbm5yZVc5dGhLT0JxRENCcFRBZEJnTlZIUTRFRmdRVVlSOHZGUVRsa2pmMS9ObktlWnh2WTBaejNhQXdEZ1lEVlIwUEFRSC9CQVFEQWdlQU1CVUdBMVVkSlFFQi93UUxNQWtHQnlpQmpGMEZBUUl3SHdZRFZSMGpCQmd3Rm9BVUw5OHdhTll2OVFueElIYjVDRmd4anZaVXRVc3dJUVlEVlIwU0JCb3dHSVlXYUhSMGNITTZMeTltZFc1clpTNWhibWx0Ynk1cFpEQVpCZ05WSFJFRUVqQVFnZzVtZFc1clpTNWhibWx0Ynk1cFpEQUtCZ2dxaGtqT1BRUURBZ05JQURCRkFpQkJ3ZFMvY0ZCczNhd3RmUDlHRlZrZ1NPSVRRZFBCTUxoc0pCeWpnN2wyTFFJaEFQUUpXeTdxUXNmcTJHcmRwY0dYSHJEVkswdy9YblBGMlhBVDZyVFg4dUNQIiwiTUlJQnp6Q0NBWFdnQXdJQkFnSVFWd0FGb2xXUWltOTRnbXlDaWMzYkNUQUtCZ2dxaGtqT1BRUURBakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d0hoY05NalF3TlRBeU1UUXlNek13V2hjTk1qZ3dOVEF5TVRReU16TXdXakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFRQy9ZeUJwY1JRWDhaWHBIZnJhMVROZFNiUzdxemdIWUhKM21zYklyOFRKTFBOWkk4VWw4ekpsRmRRVklWbHM1KzVDbENiTitKOUZVdmhQR3M0QXpBK280R1dNSUdUTUIwR0ExVWREZ1FXQkJRdjN6Qm8xaS8xQ2ZFZ2R2a0lXREdPOWxTMVN6QU9CZ05WSFE4QkFmOEVCQU1DQVFZd0lRWURWUjBTQkJvd0dJWVdhSFIwY0hNNkx5OW1kVzVyWlM1aGJtbHRieTVwWkRBU0JnTlZIUk1CQWY4RUNEQUdBUUgvQWdFQU1Dc0dBMVVkSHdRa01DSXdJS0Flb0J5R0dtaDBkSEJ6T2k4dlpuVnVhMlV1WVc1cGJXOHVhV1F2WTNKc01Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ1RnODBBbXFWSEpMYVp0MnV1aEF0UHFLSVhhZlAyZ2h0ZDlPQ21kRDUxWndJZ0t2VmtyZ1RZbHhTUkFibUtZNk1sa0g4bU0zU05jbkVKazlmR1Z3SkcrKzA9Il19.eyJjcmVkZW50aWFsX3R5cGUiOiJNU0lTRE4iLCJuYmYiOjE3NTI5ODQ3MzcsImV4cCI6MTc4NTM4NDczNywidmN0IjoiZXUuZXVyb3BhLmVjLmV1ZGkubXNpc2RuLjEiLCJjbmYiOnsia2lkIjoiZGlkOmp3azpleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TWpVMklpd2llQ0k2SWxKUk5XSkRiMngzUkZKV1pHUjRhbkk1TFUweUxVNUtPRVZ1TjFwSE1tTXpVbkZzVTJKVVR6TlJUMFVpTENKNUlqb2lZVlpFVVZkak5TMUJZbmhIYmxoV2JYRk1WMkphWmpGR1ZsWjFOVEF5TW0xaGFHdHpSVTh3VTJSZmR5SXNJblZ6WlNJNkluTnBaeUo5IzAifSwiaXNzIjoiaHR0cHM6Ly9mdW5rZS5hbmltby5pZCIsImlhdCI6MTc1Mzk0MjUyNywiX3NkIjpbIjI5SXE0b29UNzhGMkI1bFI1RzhGSGhGWWJKWmlER29vRHEySUpicFpCVG8iLCIzZVNTOEtZcUZzQVVHZVhIVWhwU21qd1k2TG5XaVJCMTVXYXRLY0ZTNzhJIiwiNE9mZGdDalZPUTJMbzhESXpTUEpodVVWT25yWGhjX1dkTGpCZDcwRGJFUSIsIkFwMWVweTdtVThiRkdrNXZkWXdlMjZma2pUY2taaW1uMDlncFlSR25XY3ciLCJEU0NWZHY3WklSOEZNNTR4c05MVlZqYndJc0JjcE9EUllHRTlCOTFra19RIiwiRnMwbGVHT0VMUU85ejhYblZsbVJTdXRUX0d3dDRTOWNubUJLcDF4TnRyQSIsIlFTbjl3dUx3LUJKY3VLRF9URHl0NGcyZlR4LU1KcmNyVzM0bVpKdHhtc0kiLCJfZDkyZVNKcW9FemdhQlctcFU2NUY2N3FOUno2Y2owRkJObDJYcTFmRWdFIiwia3VwOXhVUjZYMDZ5X3RiVVBPTzJ4VWxiWHJReG1qalRiVE9zMktYUUM4YyIsInBIYmh1eWxJbkZnaGtPY3hqcHVKb0o0S0hITUhfT2JSOWxYX0ZUa2Vmb2ciLCJ4YW1wZmJkRHJfd05LUllKN1F6NlAxZEZJcGJvMTJFdHRfZkMzYko4MDFvIl0sIl9zZF9hbGciOiJzaGEtMjU2In0.pf3MHMEAma64_-8mfmPdLCNzgzz5K0_EianTPd5IUzMlkXhB1v4NtQmRiARlLvTd9kkUChhW4lascAkW8TOnSA~WyI4NzY3MzA2NTE3OTE1MTMzMTI2NDI5MTUiLCJwaG9uZV9udW1iZXIiLCI0OTE1MTEyMzQ1NjciXQ~WyIyNzgzODk0ODU5Mjc2ODY0NTY1NjkxNzUiLCJyZWdpc3RlcmVkX2ZhbWlseV9uYW1lIiwiTXVzdGVybWFuIl0~WyI5Njk4OTYzODY5MDAwMTE3MzM0MTE0NDQiLCJyZWdpc3RlcmVkX2dpdmVuX25hbWUiLCJKb2huIE1pY2hhZWwiXQ~WyIxMDE3NzAzNzY5OTU2Mzc0MjI4NTIwMDQ4IiwiY29udHJhY3Rfb3duZXIiLHRydWVd~WyIxMTcwMTg2ODQ0MTkyNTczMzQyOTYyNDg5IiwiZW5kX3VzZXIiLGZhbHNlXQ~WyI0MzI1MjkxNDE2MzczOTU0MzgxNDM5NTUiLCJtb2JpbGVfb3BlcmF0b3IiLCJUZWxla29tX0RFIl0~WyI2ODA1NjkyNDQ3MTA1NjQ3ODc1ODQxNzUiLCJpc3N1aW5nX29yZ2FuaXphdGlvbiIsIlRlbE9yZyJd~WyI5MzE5ODU3NzkxNTk0Njc0ODE2NTg4ODciLCJ2ZXJpZmljYXRpb25fZGF0ZSIsIjIwMjMtMDgtMjUiXQ~WyI2MTkxMTk5NjI3Mzg2MDQ5MjI4ODkwMjEiLCJ2ZXJpZmljYXRpb25fbWV0aG9kX2luZm9ybWF0aW9uIiwiTnVtYmVyVmVyaWZ5Il0~WyIzNzM2NzUzNDQwNDA1ODI4Mzc2MTE0MjQiLCJpc3N1YW5jZV9kYXRlIiwiMjAyNS0wNy0yMFQwNDoxMjoxNy4wODlaIl0~WyI1NjU0NDMyNzk2MjEwMjQ2ODk0NjQ3MDgiLCJleHBpcnlfZGF0ZSIsIjIwMjYtMDctMzBUMDQ6MTI6MTcuMDg5WiJd~\"]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqIdForOpenID4VP}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "vp-result",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results v2",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-results",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "2.2. multiple vp submission - valid, expired, invalid - require_cryptographic_holder_binding false",
-          "item": [
-            {
-              "name": "vp request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"MTc3OTEwMTI1ODkzOQ==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential\",\r\n                \"format\": \"dc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"TestCredential_SD_JWT\"\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false\r\n            },\r\n            {\r\n                \"id\": \"id_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ],\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MockVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"multiple\": true,\r\n                \"require_cryptographic_holder_binding\": false\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"id_credential_query\",\r\n                        \"student_id_credential\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "1 valid, 1 expired and 1 invalid vc",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"id_credential_query\":[{\"issuanceDate\":\"2025-12-23T10:27:09.133Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"value\":\"MLE\",\"language\":\"eng\"}],\"city\":[{\"value\":\"TEST_CITYeng\",\"language\":\"eng\"}],\"phone\":\"2261640506\",\"fullName\":[{\"value\":\"TEST_FULLNAMEeng\",\"language\":\"eng\"}],\"addressLine1\":[{\"value\":\"TEST_ADDRESSLINE1eng\",\"language\":\"eng\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\"UIN\":\"2042351307\",\"email\":\"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"},\"proof\":{\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"https://api.released.mosip.net/.well-known/ida-public-key.json\",\"type\":\"RsaSignature2018\",\"created\":\"2025-12-23T10:27:09Z\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"},\"id\":\"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\"type\":[\"MOSIPVerifiableCredential\",\"VerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",{\"sec\":\"https://w3id.org/security#\"}],\"issuer\":\"https://api.released.mosip.net/.well-known/ida-controller.json\"},{\"credentialSubject\":{\"VID\":9876543210,\"gender\":[{\"language\":\"eng\",\"value\":\"Male\"},{\"language\":\"fra\",\"value\":\"M\u00e2le\"},{\"language\":\"ara\",\"value\":\"\u0630\u0643\u0631\"}],\"province\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"phone\":\"+919427357934\",\"postalCode\":45009,\"fullName\":[{\"language\":\"fra\",\"value\":\"Siddharth K Mansour\"},{\"language\":\"ara\",\"value\":\"\u062a\u062a\u06af\u0644\u062f\u0643\u0646\u0633\u064e\u0632\u0642\u0647\u0650\u0642\u0650\u0641\u0644 \u062f\u0633\u064a\u064a\u0633\u064a\u0643\u062f\u0643\u0646\u0648\u06a4\u0648\"},{\"language\":\"eng\",\"value\":\"Siddharth K Mansour\"}],\"dateOfBirth\":\"1987/11/25\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\",\"UIN\":9876543210,\"region\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"email\":\"siddhartha.km@gmail.com\"},\"validUntil\":\"2028-01-08T07:19:56.385Z\",\"validFrom\":\"2026-01-08T07:19:56.385Z\",\"id\":\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\",\"type\":[\"VerifiableCredential\",\"MockVerifiableCredential\"],\"@context\":[\"https://www.w3.org/ns/credentials/v2\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuer\":\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\",\"credentialStatus\":{\"statusPurpose\":\"revocation\",\"statusListIndex\":\"94010\",\"id\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\",\"type\":\"BitstringStatusListEntry\",\"statusListCredential\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\"},\"proof\":{\"verificationMethod\":\"did:web:mosip.github.io:inji-config:qa-inji1:landregistry#UHNnpAY2hEkSnXqkc3aS07EgTEaw9WC64kpO3jvP9X0\",\"created\":\"2025-11-24T07:37:30Z\",\"type\":\"Ed25519Signature2020\",\"proofPurpose\":\"assertionMethod\",\"proofValue\":\"z5gfKobfm77qMGgs41LDkoSjZdS7fTx19runRBxPSckQUfCxMgbmnF9SiGwgJrkuzx1yYqdvkfW7u69v5cMc3ePCp\"}}],\"student_id_credential\":[\"eyJhbGciOiJFUzI1NiIsInR5cCI6InZjK3NkLWp3dCIsIng1YyI6WyJNSUlCSkRDQnlxQURBZ0VDQWhSNE5xOStNUjVyTFZFS242U1FSd0daRHh3SWpUQUtCZ2dxaGtqT1BRUURBakFTTVJBd0RnWURWUVFEREFkRlExOVVaWE4wTUI0WERUSTFNRGt3TXpFd01qVXhPVm9YRFRJMU1Ea3dNekV3TWpreE9Wb3dFakVRTUE0R0ExVUVBd3dIUlVOZlZHVnpkREJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUFCTXJvelh2R2tuZm5SRnFDMG8vcWRwK3Zpd1lvT2drVmRRZkpuWFZMMlJjYUFHL0dOSEVYMkxPVWxJY3JtVDZNS1o4WkhFWXdWMU9tUTB5OUNOd0ViRlF3Q2dZSUtvWkl6ajBFQXdJRFNRQXdSZ0loQU9VSjkvTXdJUGVvYnJMRERhT2pLQkVuSDJoTjVTekY4dnRmOTBVZTY5NHJBaUVBeFFXeGo5dUt1MlliK2pDYk03a0lxaFcrNkNVYWk5WGNLWG9MdFNwanJEYz0iXX0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTY5MDAwMDAwMCwiaWQiOiIxMjM0IiwidmN0IjoiVGVzdENyZWRlbnRpYWxfU0RfSldUIiwiX3NkIjpbImJEVFJ2bTUtWW4tSEc3Y3FwVlI1T1ZSSVhzU2FCazU3SmdpT3FfajFWSTQiLCJldDNVZlJ5bHdWcmZYZFBLemc3OWhjakQxSXR6b1E5b0JvWFJHdE1vc0ZrIiwieldmWk5TMTlBdGJSU1RibzdzSlJuMEJaUXZXUmRjaG9DN1VaYWJGcmpZOCJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vaXNzdWVyLmV4YW1wbGUuY29tIiwibmJmIjoxNjkwMDAzNjAwLCJleHAiOjE2OTAwODAwMDB9.P5tm14I5pja6G0spZQ07HbYBZwGZCeNH86VqyfRrWYgZrx5fv75ndJdiCEV-Mvj84p8ZWLFgeY5uPoS_ypT17A~\"]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqIdForOpenID4VP}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "vp-result",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp results v2",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{txnIdForOpenID4VP}}",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-results",
-                    "{{txnIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "1.1. ldp_vp - valid signature - dcql request",
-          "item": [
-            {
-              "name": "vp request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"MTc3OTEwMTI1ODkzOQ==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"dc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"student_id_credential\"\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"last_name\",\r\n                        \"path\": [\r\n                            \"last_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"first_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"given_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"first_name\",\r\n                        \"last_name\"\r\n                    ],\r\n                    [\r\n                        \"given_name\"\r\n                    ]\r\n                ]\r\n            },\r\n            {\r\n                \"id\": \"age_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"male_gender\",\r\n                        \"path\": [\r\n                            \"gender\",\r\n                            null,\r\n                            \"value\"\r\n                        ],\r\n                        \"values\": [\"MLE\"]\r\n                    },\r\n                    {\r\n                        \"id\": \"full_name_eng\",\r\n                        \"path\": [\r\n                            \"fullName\",\r\n                            0,\r\n                            \"language\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"male_gender\",\r\n                         \"full_name_eng\"\r\n                    ],\r\n                    [\r\n                        \"full_name_eng\"\r\n                    ]\r\n                ]\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"age_credential_query\"\r\n                    ],\r\n                    [\r\n                        \"student_id_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp submission valid signature",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"age_credential_query\":[{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"type\":[\"VerifiablePresentation\"],\"verifiableCredential\":[{\"issuanceDate\":\"2026-03-27T10:34:33.914Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"language\":\"eng\",\"value\":\"MLE\"},{\"language\":\"hin\",\"value\":\"MLE\"},{\"language\":\"fra\",\"value\":\"MLE\"}],\"compressedFace\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABQADwDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCEF3607G2stH1OT/Vxk/nU8VtrEkoVouvvWftYL4dRvnm/eZLJe+VLtzUi6gAMlqzNYs5rNWkmeJHH8JcZ/KuZTxLFbyAXS5i7lRk1aqXV0hOKW7O4/tUBsbqka4nmXMQzVTw/rfgvVWWAyzLct08yHC/nmvSLPw5YJa77cxyD+8hBH6VPvt3Wg1Y84e21SXhIifzpn9la3/zw/U16jFarB0qxvqr1OrFd9Dm4LR4vuLUOv38mkaLJeKcTAhV+prei2jrWJ44svtvh5UjGT9piLf7ueaq/NLUOljltD8MN40xqeqqfNPtnrWZ4v8D2NhcPHbrzzj5a6iTxbZ+GVNpbTYQfhWDe+K7fVp/PeXND5ErdTSKs1oeeSaK1vEcAq4rtPht41utN1aLRbyUi1dSBk/xdB/Os3Vb+1ZyUfNc3DBNPr9lcQLnFxHz/AMCFZxbT12KnCL1R9TLCWO1xzUn2H2ojM33pRiSpvOuPT9a0uYcyMmKGL+Osm/Mr6mLYD/RDnJq75+/vVO+ult4yzNgVME27FxaTbZxPjDwDb3908tlJ8/OA2APzrOg8BDT/AArJNdKn2pcY2EMOh71vXetlrjyy+Iz1NYWuazqkVs8VnLEbPvmUA/lWslFdDSNmjh10ySX7y1s6DCtnqtqk3yxiRSPrkYqrZ6jI2Nxrp9B0r+29ThTbu2kSfkc1zt6WJkktT3COdrgCVutTeZVW2+S3xTt1U2cyi7s5m1dWAya868c+JJ7bX49Ojb90clhnuDXoaCG2/wBYcYrx/wCIUcbeIxdxHI3FQfcmrj7zsi5STi13NON4rpME5kPasvUrLywQUGavzWEtroFrewL/AKV5eX+tcy+sajcRk3Iw/wBaTbta5rGTtdiwosbgNwK9a+Flq6pdX5H3TsjP+yRzXibXU7P83T612/w+8f8A9nSy6TdyMkbOBGewA459KiEfesObUonuplCrgGovO96pQahaXAxFOkme6MCKs7Upqxje54xc+Lb67J+bOfeub1OeW8mUT/dVw34g0WPQUuo969ZcvI0lucNNtvU7XT5Jb7SNw5Q45rl9YsljdiBXe+BLWOfwt83t/I0mp6DaSbsj9K5J0bu6PSjLQ8dnO3NZs0u5sE8V0/iYaZp872yl/P7YTj8649ySeaz9mkiJTurG3pPiHVNHkU2d7KsS/wDLMHANdR/wtTW/Qf8AfZrgYvuVJR7R9Dmluf/Z\",\"phone\":\"7367102638\",\"fullName\":[{\"language\":\"eng\",\"value\":\"TEST_FULLNAMEeng\"},{\"language\":\"hin\",\"value\":\"TEST_FULLNAMEhin\"},{\"language\":\"fra\",\"value\":\"TEST_FULLNAMEfra\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0=\",\"UIN\":\"3920190347\",\"claim169\":{\"identityQRCode\":\"NCF4:OWBBPP3F:H37MMC2Y48.6H-2S6612S3T3MC 3QM3+NV/-KCFI3IO-THZL0PXMYHFEPJ1$LOOQ8HP7CU*GBEWH55MRNRO.7-MEV2ITVNSRE:XRO:TT7LMFV*ITX/L WOU-JL0QKXDH S02S4O3YNVF%PIQJ/4NN873KFOM3-NEUEDV0FC:6//EW S4+DNC7M.Q*IET7VN06D+MO4A*9F4SUBCFEJVHAO 8TF7TMKIG.F5W6CZR6JN.5G6ZUSDSQ:1V SIBS7*JXYPH02YJMH-9KZUJ8MM:T87K0AV+W9ZSV%0N7CPK U6A6-OD$QVW8TW4T*3QBKUXEF4IV.5N5SM08B6JPS3WHUVH6EB.SKJ23F6/8SS5S2ZKJB6N:91BJTBPLPP%BH1Y98JTTDS8SO7WSKLIUSC+RNZXNWW7SKR9PI/%PVT28P6NEB1XLN/FM5S86GG2RE.O-7S0/40UQKCJB0F-NTK+8S5T68PHLC87B:KUV L1HB0U6:PE4SJB1VA1R4ZLO33V+LI4N2NMHUI8QIIMJ/DA +PK%95$UI7QU38C5P8YT5/3C2GXWCRF6-3EYDR4PDTHE+TE$3BDHRY$I*.3%HKCT4:F0A$SNC6XQ5AP6425ZNHGTLZ:LKM530C-IF8EVPEW6144+5LYH418P0S:APHF4XWTIIE:$H5KD*A7-+8Z/P 1QZPGJ+F91F 3UY4EWV1443%N53YH9CEM5P*9AMBV9GVTZH7YGPAI:*ST%RGSPT.1TJC7R0PUIA7PRWS4+AF5FR2RYXUTXMNYEE14Z6OL2RB-5D9JI+65KVW7QAX1RQ1L48W:EOTC%HT.GKP92:ESK+800W551 YFLW1.V3LRRO4PMKFZ48LVHXSKNERX*UKLEV/4J36 P4XQIQBCME4:9BJG1A 63THA$3S2CF:4$NAAAD$HMTZS5ASOMH91ATL75CA2Y958VMH4KCG7J6%F8/DLI35V 3I5JTEO.28/WG0*P-TKF8RA823F4LK0L%H4T6I0KIO1B.8U8F25WG18IUIX6W9:VTO6MDW5:V/5CFIM8O55HAZXVE2G:*7SCWK5BI0D:OQ GUEXKC7F1RP.JEJHS3DF-V2*OGWVLW664A5 0P/JPS2J++14/8:EH3CQ%QU$A8CFPMQSQ$78K3.7QVRC9E2U ECFVMB8-%F.Z6PYB7Q3V PJRJNKO-844USZYG*EMMEO$TC*80.F6Q$FEPTZAW.0Q2 8D70APMYTI$$O3CB.VLSE6GNBO0FBGMUWKH:RSAL$MI2:KR.3TWVD3JLZLZAL1PBMESI%RFB2/$F9OSLWSUWBOJV$41P/HO.Q$MCUZNUH2P*UT-U$0E2LL 0IGPKS46: 5UA422SJ3T*GOE4P*.B68G8*Q.3U66RB4UWQ7GSL7%AHPJHX25RPIUVU.4SGVLIC2*59BRO 7$ZAOCOJV7RY11ON/AQ0406AT%GQGMR1+MNRE+W1PCSU7551Q RAFH8YY74$OUXAX8LLCOX NBV4$/8AJP2+6EJ5U1A+XGQ%LIMCC-H6890AHOF1W1RAKMPRGKNQZFUV3A0WK4.89YFN%R64HYWA*FGKVB/XKCZE4-2H113R4Y QB.F6$JCP3OZGPFR3+GQ OLLR UQX81SPHUIGK:KJQNG/KAX1TLMN45M/HT51%XP4-AN91HRGE/MPQFXN4EWPGRERZR$K0P07BNP.X5TACJGITNOCKQ$GVQV5+$4DI4FHAR$CP2DP76R*9S5D*/JV*87KVU9S.SL:DAO.0/J5VES*QNY%9O44MOH2PHU98 Y0J-38$1KU8XGH8J8/22BFRU F9LMO:O%-DSM78GF2ZV6XUD8JPYHOKK/YL0:58$KPNF.54DTO7TL$ES%ODC-DZPL+Y2TM1P*C$A6A J*VQJ*FSRD+6GGY43TO+4P5870LF*9Q.F8UWB29A2NJV 615O%/0C%EA*48NKW70-46.HHMVV$992BLZ24Y8OI Q$CR%+KO$E5TRO7O+-BGF1PV2XKS-J51LUMVLBF5*KQY-Q:RHIYNTJLPHRPCI2OG.AT2NVT%EA%RWJ591L67DWI3ILGU-7E16DCNH90.YK 2HE$S*$O%:BNQB3FF-AFEZ19RTA6G5CI467B:O8162XRY08MC5MKLN*K9BLA-E0%4RTT KS ONQBPC$UF-GN-1I7A 3FG11COKF89R3T0H74A7TH8F60NA6UNTHKOQOPUVE5SRF-0BFU.RVNFD/1Q$AE%LDHZ5$GD:M7K:P9G1Z60OP88ZSSLHIDT2STR8WXX7NLFYNLO.1X6JTYDNGBTUUL*8G*K.TO8XD1H533L/FQI$OK:MPPQ:XAZF6G O.*J6%4EX8J44/59.499ORDE77EMGTSX0IK/NFV9VJGSAB*$I1JL$JHB7RVAH0MCBF58 D0229THYTN1JQ8B9U9EBVAWBLJLG%OKPS8E$FXFPF3GJRDA:H+469-MHW43+OB*Q1TT4D8ECEISTVYKY7D:UVMWH%X66I7RHM$%6P V/YJS0CHZ54J42BL9$LBC1+FB$F5JD8J72C3HQFIUQLGY1T7S2A4RHGY/B414EKS:BC$FW*Q933K5B0HJKXDLEMKNU1+UM.24Q*51J55U0P:HM C:5L$FEMA2%XSUGE4W2FBLYBK6:UPCRE+VGWB3OF:$S D3/7NPFCXHBY*D:JLS8EU.DG1VM.DJ*JCCOCYN+7AUEIQXT:LIXZVRGPWXQ36VV-OCWEN.PT275919GE*CN%*QKJA6U9RFGTEP%-F2H9AFTTF3-ETQKEEBTSOKFPD0.J3B2JHNFF43JDHY8PBNUG6UULZ34HQSA/4GKCPY2DK1HQ8RWM1H7ZMFYYVR7RLIB3*EG:JJWFBDCV4NJJ8*%GE2MQI8QOBFJNQ2V:H95ZIR996HAUUMKH0*GEL5BJP8CV3J7K ZM23J-:J8P83M8W7ALAE73PLLID6636R1N3N4AP+GM$C4ILP%4:E7322DHLBX3G*PPCJ6N90G42.KKZAVJM3:O+UJARBKUOR+EPN8G5PJJKMHB4+K-*8BPAUFKLXL.*8AUE /AZ+7LEJSCTCDNS$8BUH9 P1N9-08KJCK%MYZK43L6/AAJCSFW7FKZ*HRRPXNNYP2X*M2Q9K9Q9VD:+F/IBQJ9IFWY21AA9/%8XELV:AA5E9E22/L3LCXT8/HRYY2Z$K*:1TGT8L6-VC9XO*I508GJ11O.77V4GYF1 2UZFZ53DTVNGEG6D3XQ6QD-U6/VN0CRR*6-.MV1EC*3N28.-AD-F5:AI%G1ZR%+5+BP04F-9QUEJR0K-XHW5E-+37QNJEUKFVGUG86F6DU CVF*LPP9/N3IDKS68*8J6IJ$HQ:129F289KV7TW40E%6.4\"},\"email\":\"IdRepository_AddIdentity_AuthStatus_Vid_Valid_smoke_Pos@mosip.net\"},\"id\":\"https://mosip.io/credential/752bf960-c9d7-4bab-94bc-ca4af28016c2\",\"type\":[\"VerifiableCredential\",\"MOSIPVerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://inji.github.io/inji-config/contexts/mosip-identity-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuer\":\"did:web:inji.github.io:inji-config:dev-int-inji:mosipid-identity\",\"expirationDate\":\"2028-03-26T10:34:33.914Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2026-03-27T10:34:33Z\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:web:inji.github.io:inji-config:dev-int-inji:mosipid-identity#7TmkqqmmpxilQ_H54iWD1Uea90JTiup_p9mUi90UMvA\",\"proofValue\":\"z4jFVQRdQq5taLtmByFUxHDStQxbFefT9M964ZK6VFVKKPNa5cztzQKxMHBTDcEhS6mQMSnv4Vf2YBFcTvXBooqTR\"}}],\"id\":\"urn:uuid:fa9de180-b5df-433b-b9be-6736ddf890bf\",\"holder\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0#0\",\"proof\":{\"type\":\"JsonWebSignature2020\",\"created\":\"2026-05-18T10:48:03Z\",\"challenge\":\"MTc3OTEwMTI1ODkzOQ==\",\"domain\":\"did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFZERTQSJ9..rDRxjHNFXE4WP7JH7aFExBbd91C-dZPTHwTeQduas-jBAaedr7nnLF4k9VtfWoOkLOpLLQYYjKFVeLFJYq2TCA\",\"proofPurpose\":\"authentication\",\"verificationMethod\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0#0\"}}]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqIdForOpenID4VP}}",
+                      "value": "{{1_1_reqId}}",
                       "type": "text"
                     },
                     {
@@ -2807,7 +1143,7 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-request/{{reqIdForOpenID4VP}}/status",
+                  "raw": "{{base_url}}/v1/verify/vp-request/{{1_1_reqId}}/status",
                   "host": [
                     "{{base_url}}"
                   ],
@@ -2815,7 +1151,7 @@
                     "v1",
                     "verify",
                     "vp-request",
-                    "{{reqIdForOpenID4VP}}",
+                    "{{1_1_reqId}}",
                     "status"
                   ]
                 }
@@ -2846,7 +1182,7 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForOpenID4VP}}",
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{1_1_txnId}}",
                   "host": [
                     "{{base_url}}"
                   ],
@@ -2854,7 +1190,7 @@
                     "v1",
                     "verify",
                     "vp-result",
-                    "{{txnIdForOpenID4VP}}"
+                    "{{1_1_txnId}}"
                   ]
                 }
               },
@@ -2869,7 +1205,8 @@
                     "exec": [
                       "pm.test(\"Status code is 200\", function () {",
                       "    pm.response.to.have.status(200);",
-                      "});"
+                      "});",
+                      ""
                     ],
                     "type": "text/javascript",
                     "packages": {},
@@ -2893,7 +1230,7 @@
                   }
                 },
                 "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{txnIdForOpenID4VP}}",
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{1_1_txnId}}",
                   "host": [
                     "{{base_url}}"
                   ],
@@ -2902,7 +1239,7 @@
                     "verify",
                     "v2",
                     "vp-results",
-                    "{{txnIdForOpenID4VP}}"
+                    "{{1_1_txnId}}"
                   ]
                 }
               },
@@ -2911,7 +1248,7 @@
           ]
         },
         {
-          "name": "1.2. ldp_vp - invalid signature - dcql request",
+          "name": "1.2 ldp_vp - invalid signature - dcql request",
           "item": [
             {
               "name": "vp request using dcql",
@@ -2921,8 +1258,8 @@
                   "script": {
                     "exec": [
                       "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
+                      "pm.collectionVariables.set('1_2_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('1_2_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -2942,7 +1279,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\r\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n            \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"dc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"student_id_credential\"\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"last_name\",\r\n                        \"path\": [\r\n                            \"last_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"first_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"given_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"first_name\",\r\n                        \"last_name\"\r\n                    ],\r\n                    [\r\n                        \"given_name\"\r\n                    ]\r\n                ]\r\n            },\r\n            {\r\n                \"id\": \"age_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"male_gender\",\r\n                        \"path\": [\r\n                            \"gender\",\r\n                            null,\r\n                            \"value\"\r\n                        ],\r\n                        \"values\": [\"MLE\"]\r\n                    },\r\n                    {\r\n                        \"id\": \"full_name_eng\",\r\n                        \"path\": [\r\n                            \"fullName\",\r\n                            0,\r\n                            \"language\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"male_gender\",\r\n                         \"full_name_eng\"\r\n                    ],\r\n                    [\r\n                        \"full_name_eng\"\r\n                    ]\r\n                ]\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"age_credential_query\"\r\n                    ],\r\n                    [\r\n                        \"student_id_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "raw": "{\r\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\r\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n            \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"dc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"student_id_credential\"\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"last_name\",\r\n                        \"path\": [\r\n                            \"last_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"first_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"given_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"first_name\",\r\n                        \"last_name\"\r\n                    ],\r\n                    [\r\n                        \"given_name\"\r\n                    ]\r\n                ]\r\n            },\r\n            {\r\n                \"id\": \"mosip_verifiable_credential_id\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"male_gender\",\r\n                        \"path\": [\r\n                            \"gender\",\r\n                            null,\r\n                            \"value\"\r\n                        ],\r\n                        \"values\": [\"MLE\"]\r\n                    },\r\n                    {\r\n                        \"id\": \"full_name_eng\",\r\n                        \"path\": [\r\n                            \"fullName\",\r\n                            0,\r\n                            \"language\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"male_gender\",\r\n                         \"full_name_eng\"\r\n                    ],\r\n                    [\r\n                        \"full_name_eng\"\r\n                    ]\r\n                ]\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"mosip_verifiable_credential_id\"\r\n                    ],\r\n                    [\r\n                        \"student_id_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2992,12 +1329,12 @@
                   "urlencoded": [
                     {
                       "key": "vp_token",
-                      "value": "{\"age_credential_query\":[{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"type\":[\"VerifiablePresentation\"],\"verifiableCredential\":[{\"issuanceDate\":\"2025-11-23T10:27:09.133Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"value\":\"MLE\",\"language\":\"eng\"}],\"city\":[{\"value\":\"TEST_CITYeng\",\"language\":\"eng\"}],\"phone\":\"2261640506\",\"fullName\":[{\"value\":\"TEST_FULLNAMEeng\",\"language\":\"eng\"}],\"addressLine1\":[{\"value\":\"TEST_ADDRESSLINE1eng\",\"language\":\"eng\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\"UIN\":\"2042351307\",\"email\":\"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"},\"proof\":{\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"https://api.released.mosip.net/.well-known/ida-public-key.json\",\"type\":\"RsaSignature2018\",\"created\":\"2025-12-23T10:27:09Z\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"},\"id\":\"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\"type\":[\"MOSIPVerifiableCredential\",\"VerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",{\"sec\":\"https://w3id.org/security#\"}],\"issuer\":\"https://api.released.mosip.net/.well-known/ida-controller.json\"}],\"id\":\"urn:uuid:b978c646-8c07-4c1f-9598-f3e5f195d342\",\"holder\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\",\"proof\":{\"type\":\"JsonWebSignature2020\",\"created\":\"2025-11-23T16:02:51Z\",\"challenge\":\"oNjl1LmAXj6pqygwQnMBFQ==\",\"domain\":\"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\"jws\":\"eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..QsdZRqx7X8HcuDD8R55FCpeuGMVLiMZnmZYoKpZ_B1r5FH687Xy15XMwH56gl8-6sGrwU9pdQctdN0afx_dkAg\",\"proofPurpose\":\"authentication\",\"verificationMethod\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\"}}]}",
+                      "value": "{\"mosip_verifiable_credential_id\":[{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"type\":[\"VerifiablePresentation\"],\"verifiableCredential\":[{\"issuanceDate\":\"2025-11-23T10:27:09.133Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"value\":\"MLE\",\"language\":\"eng\"}],\"city\":[{\"value\":\"TEST_CITYeng\",\"language\":\"eng\"}],\"phone\":\"2261640506\",\"fullName\":[{\"value\":\"TEST_FULLNAMEeng\",\"language\":\"eng\"}],\"addressLine1\":[{\"value\":\"TEST_ADDRESSLINE1eng\",\"language\":\"eng\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\"UIN\":\"2042351307\",\"email\":\"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"},\"proof\":{\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"https://api.released.mosip.net/.well-known/ida-public-key.json\",\"type\":\"RsaSignature2018\",\"created\":\"2025-12-23T10:27:09Z\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"},\"id\":\"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\"type\":[\"MOSIPVerifiableCredential\",\"VerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",{\"sec\":\"https://w3id.org/security#\"}],\"issuer\":\"https://api.released.mosip.net/.well-known/ida-controller.json\"}],\"id\":\"urn:uuid:b978c646-8c07-4c1f-9598-f3e5f195d342\",\"holder\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\",\"proof\":{\"type\":\"JsonWebSignature2020\",\"created\":\"2025-11-23T16:02:51Z\",\"challenge\":\"IvfM76kOqj8Xy5H9pFBGBQ\",\"domain\":\"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\"jws\":\"eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..QsdZRqx7X8HcuDD8R55FCpeuGMVLiMZnmZYoKpZ_B1r5FH687Xy15XMwH56gl8-6sGrwU9pdQctdN0afx_dkAg\",\"proofPurpose\":\"authentication\",\"verificationMethod\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\"}}]}",
                       "type": "text"
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForOpenID4VP}}",
+                      "value": "{{1_2_reqId}}",
                       "type": "text"
                     },
                     {
@@ -3054,7 +1391,7 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-request/{{reqIdForOpenID4VP}}/status",
+                  "raw": "{{base_url}}/v1/verify/vp-request/{{1_2_reqId}}/status",
                   "host": [
                     "{{base_url}}"
                   ],
@@ -3062,7 +1399,7 @@
                     "v1",
                     "verify",
                     "vp-request",
-                    "{{reqIdForOpenID4VP}}",
+                    "{{1_2_reqId}}",
                     "status"
                   ]
                 }
@@ -3093,7 +1430,7 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForOpenID4VP}}",
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{1_2_txnId}}",
                   "host": [
                     "{{base_url}}"
                   ],
@@ -3101,7 +1438,7 @@
                     "v1",
                     "verify",
                     "vp-result",
-                    "{{txnIdForOpenID4VP}}"
+                    "{{1_2_txnId}}"
                   ]
                 }
               },
@@ -3140,7 +1477,7 @@
                   }
                 },
                 "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{txnIdForOpenID4VP}}",
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{1_2_txnId}}",
                   "host": [
                     "{{base_url}}"
                   ],
@@ -3149,7 +1486,7 @@
                     "verify",
                     "v2",
                     "vp-results",
-                    "{{txnIdForOpenID4VP}}"
+                    "{{1_2_txnId}}"
                   ]
                 }
               },
@@ -3168,8 +1505,8 @@
                   "script": {
                     "exec": [
                       "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
+                      "pm.collectionVariables.set('1_3_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('1_3_reqId', responseJson.requestId);",
                       "",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
@@ -3190,7 +1527,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"decentralized_identifier:did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"MTc3OTEwMTI1ODkzOQ==\",\r\n    \"responseCodeValidationRequired\": true,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"dc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"student_id_credential\"\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"last_name\",\r\n                        \"path\": [\r\n                            \"last_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"first_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"given_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"first_name\",\r\n                        \"last_name\"\r\n                    ],\r\n                    [\r\n                        \"given_name\"\r\n                    ]\r\n                ]\r\n            },\r\n            {\r\n                \"id\": \"age_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"male_gender\",\r\n                        \"path\": [\r\n                            \"gender\",\r\n                            null,\r\n                            \"value\"\r\n                        ],\r\n                        \"values\": [\r\n                            \"MLE\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"full_name_eng\",\r\n                        \"path\": [\r\n                            \"fullName\",\r\n                            0,\r\n                            \"language\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"male_gender\",\r\n                        \"full_name_eng\"\r\n                    ],\r\n                    [\r\n                        \"full_name_eng\"\r\n                    ]\r\n                ]\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"age_credential_query\"\r\n                    ],\r\n                    [\r\n                        \"student_id_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "raw": "{\r\n    \"clientId\": \"decentralized_identifier:did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"yMRlSK2ZT31GdWbedhk4hA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"dc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"student_id_credential\"\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"last_name\",\r\n                        \"path\": [\r\n                            \"last_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"first_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"given_name\",\r\n                        \"path\": [\r\n                            \"first_name\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"first_name\",\r\n                        \"last_name\"\r\n                    ],\r\n                    [\r\n                        \"given_name\"\r\n                    ]\r\n                ]\r\n            },\r\n            {\r\n                \"id\": \"mosip_verifiable_credential_id\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"male_gender\",\r\n                        \"path\": [\r\n                            \"gender\",\r\n                            null,\r\n                            \"value\"\r\n                        ],\r\n                        \"values\": [\"MLE\"]\r\n                    },\r\n                    {\r\n                        \"id\": \"full_name_eng\",\r\n                        \"path\": [\r\n                            \"fullName\",\r\n                            0,\r\n                            \"language\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"male_gender\",\r\n                         \"full_name_eng\"\r\n                    ],\r\n                    [\r\n                        \"full_name_eng\"\r\n                    ]\r\n                ]\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"mosip_verifiable_credential_id\"\r\n                    ],\r\n                    [\r\n                        \"student_id_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -3247,7 +1584,7 @@
                   }
                 ],
                 "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-request/{{reqIdForOpenID4VP}}",
+                  "raw": "{{base_url}}/v1/verify/v2/vp-request/{{1_3_reqId}}",
                   "host": [
                     "{{base_url}}"
                   ],
@@ -3256,459 +1593,7 @@
                     "verify",
                     "v2",
                     "vp-request",
-                    "{{reqIdForOpenID4VP}}"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "3.1. vp-request with response_code",
-          "item": [
-            {
-              "name": "vp request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "",
-                      "var txnId = responseJson.transactionId;",
-                      "var encodedTxnId = btoa(txnId);",
-                      "const transaction_id = \"transaction_id=\"+ encodedTxnId;",
-                      "pm.collectionVariables.set('txnId_with_response_code', transaction_id);",
-                      "pm.collectionVariables.set('reqId_with_response_code', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net/\",\r\n    \"nonce\": \"MTc3OTI2OTc3ODcyNw==\",\r\n    \"responseCodeValidationRequired\": true,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"insurance_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"InsuranceCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp submission valid signature",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "var redirectUri = responseJson.redirect_uri;",
-                      "",
-                      "if (redirectUri) {",
-                      "    const url = new URL(redirectUri);",
-                      "    const params = new URLSearchParams(url.hash.substring(1));",
-                      "    const responseCode = params.get(\"response_code\");",
-                      "    const transactionId = params.get(\"transaction_id\");",
-                      "",
-                      "    pm.collectionVariables.set(\"response_code\", responseCode);",
-                      "    pm.collectionVariables.set(\"transaction_id\", transactionId);",
-                      "",
-                      "    console.log(\"Captured Response Code: \" + responseCode);",
-                      "    console.log(\"Captured Transaction ID (Base64): \" + transactionId);",
-                      "} else {",
-                      "    pm.collectionVariables.set(\"response_code\", null);",
-                      "    pm.collectionVariables.set(\"transaction_id\", null);",
-                      "}",
-                      "",
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"insurance_credential_query\":[{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"type\":[\"VerifiablePresentation\"],\"verifiableCredential\":[{\"id\":\"did:rcw:8cf5afb3-0ce2-46a4-8614-7d92ef4752e0\",\"type\":[\"VerifiableCredential\",\"InsuranceCredential\"],\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2026-05-20T07:57:29Z\",\"proofValue\":\"z5p7KSt69jAGgdZzYEosJkeLPniuuegd6nNZKnpQcFDobAXEuBQxqBaEaNkxfMtm1mjdD194urJxaAjFKSMnnFxRx\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f#key-0\"},\"issuer\":\"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f\",\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://inji.github.io/inji-config/contexts/insurance-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuanceDate\":\"2026-05-20T07:57:28.984Z\",\"expirationDate\":\"2031-05-20T07:57:28.926Z\",\"credentialSubject\":{\"id\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0=\",\"dob\":\"2025-01-01\",\"email\":\"abcd@gmail.com\",\"gender\":\"Male\",\"mobile\":\"0123456789\",\"benefits\":[\"Critical Surgery\",\"Full body checkup\"],\"fullName\":\"wallettest14\",\"policyName\":\"wallettest14\",\"policyNumber\":\"55555569\",\"policyIssuedOn\":\"2026-05-19\",\"policyExpiresOn\":\"2035-04-20\"}}],\"id\":\"urn:uuid:8d84498e-bf05-4590-bf3d-12d82293c9b1\",\"holder\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0#0\",\"proof\":{\"type\":\"JsonWebSignature2020\",\"created\":\"2026-05-20T09:36:35Z\",\"challenge\":\"MTc3OTI2OTc3ODcyNw==\",\"domain\":\"injiverify.dev-int-inji.mosip.net/\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFZERTQSJ9..zGltT_l25Q6JTZPDdH2mRMXVWqQSEr5UX-esA4V_A4HPhM45jVx4M4Z2AJWzXgufKfMzPAKTk00mwIvAif3mCQ\",\"proofPurpose\":\"authentication\",\"verificationMethod\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0#0\"}}]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqId_with_response_code}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp session results with response_code",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Cookie",
-                    "value": "{{txnId_with_response_code}}",
-                    "type": "text"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true,\n  \"responseCode\": \"{{response_code}}\"\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-session-results",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "vp-session-results"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "3.2. vp-session-request with response_code",
-          "item": [
-            {
-              "name": "vp session request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "",
-                      "const encoded = btoa(responseJson.transactionId);",
-                      "const transactionId = \"transaction_id=\"+ encoded;",
-                      "pm.collectionVariables.set('txnId_VPSession_With_Response_Code', transactionId);",
-                      "pm.collectionVariables.set('reqId_VPSession_With_Response_Code', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net/\",\r\n    \"nonce\": \"MTc3OTI2OTc3ODcyNw==\",\r\n    \"responseCodeValidationRequired\": true,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"insurance_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"InsuranceCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-session-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-session-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp submission valid signature",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "var redirectUri = responseJson.redirect_uri;",
-                      "",
-                      "if (redirectUri) {",
-                      "    const url = new URL(redirectUri);",
-                      "    const params = new URLSearchParams(url.hash.substring(1));",
-                      "    const responseCode = params.get(\"response_code\");",
-                      "    const transactionId = params.get(\"transaction_id\");",
-                      "",
-                      "    pm.collectionVariables.set(\"response_code\", responseCode);",
-                      "    pm.collectionVariables.set(\"transaction_id\", transactionId);",
-                      "",
-                      "    console.log(\"Captured Response Code: \" + responseCode);",
-                      "    console.log(\"Captured Transaction ID (Base64): \" + transactionId);",
-                      "} else {",
-                      "    pm.collectionVariables.set(\"response_code\", null);",
-                      "    pm.collectionVariables.set(\"transaction_id\", null);",
-                      "}",
-                      "",
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"insurance_credential_query\":[{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"type\":[\"VerifiablePresentation\"],\"verifiableCredential\":[{\"id\":\"did:rcw:8cf5afb3-0ce2-46a4-8614-7d92ef4752e0\",\"type\":[\"VerifiableCredential\",\"InsuranceCredential\"],\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2026-05-20T07:57:29Z\",\"proofValue\":\"z5p7KSt69jAGgdZzYEosJkeLPniuuegd6nNZKnpQcFDobAXEuBQxqBaEaNkxfMtm1mjdD194urJxaAjFKSMnnFxRx\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f#key-0\"},\"issuer\":\"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f\",\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://inji.github.io/inji-config/contexts/insurance-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuanceDate\":\"2026-05-20T07:57:28.984Z\",\"expirationDate\":\"2031-05-20T07:57:28.926Z\",\"credentialSubject\":{\"id\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0=\",\"dob\":\"2025-01-01\",\"email\":\"abcd@gmail.com\",\"gender\":\"Male\",\"mobile\":\"0123456789\",\"benefits\":[\"Critical Surgery\",\"Full body checkup\"],\"fullName\":\"wallettest14\",\"policyName\":\"wallettest14\",\"policyNumber\":\"55555569\",\"policyIssuedOn\":\"2026-05-19\",\"policyExpiresOn\":\"2035-04-20\"}}],\"id\":\"urn:uuid:8d84498e-bf05-4590-bf3d-12d82293c9b1\",\"holder\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0#0\",\"proof\":{\"type\":\"JsonWebSignature2020\",\"created\":\"2026-05-20T09:36:35Z\",\"challenge\":\"MTc3OTI2OTc3ODcyNw==\",\"domain\":\"injiverify.dev-int-inji.mosip.net/\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFZERTQSJ9..zGltT_l25Q6JTZPDdH2mRMXVWqQSEr5UX-esA4V_A4HPhM45jVx4M4Z2AJWzXgufKfMzPAKTk00mwIvAif3mCQ\",\"proofPurpose\":\"authentication\",\"verificationMethod\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0#0\"}}]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqId_VPSession_With_Response_Code}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp session results with response_code",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {",
-                      "    pm.response.to.have.status(200);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Cookie",
-                    "value": "{{txnId_VPSession_With_Response_Code}}",
-                    "type": "text"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true,\n  \"responseCode\": \"{{response_code}}\"\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-session-results",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "vp-session-results"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "3.3. vp-session-request without response_code",
-          "item": [
-            {
-              "name": "vp session request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "",
-                      "const encoded = btoa(responseJson.transactionId);",
-                      "const transactionId = \"transaction_id=\"+ encoded;",
-                      "pm.collectionVariables.set('txnId_VPSession_Without_Response_Code', transactionId);",
-                      "pm.collectionVariables.set('reqId_VPSession_Without_Response_Code', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net/\",\r\n    \"nonce\": \"MTc3OTI2OTc3ODcyNw==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"insurance_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"InsuranceCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-session-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-session-request"
+                    "{{1_3_reqId}}"
                   ]
                 }
               },
@@ -3742,12 +1627,12 @@
                   "urlencoded": [
                     {
                       "key": "vp_token",
-                      "value": "{\"insurance_credential_query\":[{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"type\":[\"VerifiablePresentation\"],\"verifiableCredential\":[{\"id\":\"did:rcw:8cf5afb3-0ce2-46a4-8614-7d92ef4752e0\",\"type\":[\"VerifiableCredential\",\"InsuranceCredential\"],\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2026-05-20T07:57:29Z\",\"proofValue\":\"z5p7KSt69jAGgdZzYEosJkeLPniuuegd6nNZKnpQcFDobAXEuBQxqBaEaNkxfMtm1mjdD194urJxaAjFKSMnnFxRx\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f#key-0\"},\"issuer\":\"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f\",\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://inji.github.io/inji-config/contexts/insurance-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuanceDate\":\"2026-05-20T07:57:28.984Z\",\"expirationDate\":\"2031-05-20T07:57:28.926Z\",\"credentialSubject\":{\"id\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0=\",\"dob\":\"2025-01-01\",\"email\":\"abcd@gmail.com\",\"gender\":\"Male\",\"mobile\":\"0123456789\",\"benefits\":[\"Critical Surgery\",\"Full body checkup\"],\"fullName\":\"wallettest14\",\"policyName\":\"wallettest14\",\"policyNumber\":\"55555569\",\"policyIssuedOn\":\"2026-05-19\",\"policyExpiresOn\":\"2035-04-20\"}}],\"id\":\"urn:uuid:8d84498e-bf05-4590-bf3d-12d82293c9b1\",\"holder\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0#0\",\"proof\":{\"type\":\"JsonWebSignature2020\",\"created\":\"2026-05-20T09:36:35Z\",\"challenge\":\"MTc3OTI2OTc3ODcyNw==\",\"domain\":\"injiverify.dev-int-inji.mosip.net/\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFZERTQSJ9..zGltT_l25Q6JTZPDdH2mRMXVWqQSEr5UX-esA4V_A4HPhM45jVx4M4Z2AJWzXgufKfMzPAKTk00mwIvAif3mCQ\",\"proofPurpose\":\"authentication\",\"verificationMethod\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0#0\"}}]}",
+                      "value": "{\n  \"mosip_verifiable_credential_id\": [\n    {\n      \"proof\": {\n        \"jws\": \"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFZERTQSJ9..frOeGM8uGPANFXa940gGCd5_Hw2zLRH87AC5nJHTtjKc-1lPJlF3fdenI1oA9roHW8Q77C5itAgAzZNc8BLEBA\",\n        \"type\": \"JsonWebSignature2020\",\n        \"challenge\": \"yMRlSK2ZT31GdWbedhk4hA\",\n        \"verificationMethod\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ#0\",\n        \"domain\": \"decentralized_identifier:did:web:injiverify.dev-int-inji.mosip.net:v1:verify\"\n      },\n      \"holder\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ#0\",\n      \"verifiableCredential\": [\n        {\n          \"expirationDate\": \"2028-06-14T14:11:31.180Z\",\n          \"proof\": {\n            \"created\": \"2026-06-15T14:11:31Z\",\n            \"proofValue\": \"z534RdN9XUQGLFHszC4MnN4f5PfKYcCq2Cjtbb8MH2nQe1x2kcL4Q9NhqGUAr4MgjFSfFWsgozGeVAkKsEg4RcF5N\",\n            \"verificationMethod\": \"did:web:inji.github.io:inji-config:dev-int-inji:mosipid-identity#7TmkqqmmpxilQ_H54iWD1Uea90JTiup_p9mUi90UMvA\",\n            \"type\": \"Ed25519Signature2020\",\n            \"proofPurpose\": \"assertionMethod\"\n          },\n          \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://inji.github.io/inji-config/contexts/mosip-identity-context.json\",\n            \"https://w3id.org/security/suites/ed25519-2020/v1\"\n          ],\n          \"credentialSubject\": {\n            \"phone\": \"7367102638\",\n            \"dateOfBirth\": \"1992/04/15\",\n            \"UIN\": \"3920190347\",\n            \"fullName\": [\n              {\n                \"language\": \"eng\",\n                \"value\": \"TEST_FULLNAMEeng\"\n              },\n              {\n                \"language\": \"hin\",\n                \"value\": \"TEST_FULLNAMEhin\"\n              },\n              {\n                \"language\": \"fra\",\n                \"value\": \"TEST_FULLNAMEfra\"\n              }\n            ],\n            \"face\": \"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\n            \"claim169\": {\n              \"identityQRCode\": \"NCF4:ODGDE%SY0I37MMC2Y48%7HZ6UQ GNR3/ZBAX7L*69 U5L6+L8SEH $2F0141KX8Q%7R9+C9 H509::FNYPD2D4FE8CQB3VD:I81FP8SDVJ$%R0YD5D7$VN:29N$DZ+30/T2ZDP%CEU3VDU17SL8QUSC5XQU8NY6P:4RNMR-+I41AKTMB6OCLMRL3W1E$AQ:XLSHI3EMYWFI%LZ8FV7PYVINKOO6PU+VVY6W079.HUEVPFL0FRN5MAHP29TL.79URQ7FK3WO9M:$C3ZV V7ZCQ7.D9MU*GM%8TD3QK5KI5C$GPSAJR8KM.HDFB5LPG07M27BHE1MGD4N0JO2XMA8J5QR5NRK4G:DSS.L5T78NKG2H9$V$N7/YMK*0HEHGTEXDNNDF-MQMEHU/JXOBICJ.VF.SUS$P$AREEV-9TDQF$F2DFBSH8R-C5K1N+E1AM1UFRBQHRN0639O3KUCQD3$SE.*9W 7ADHSXBHHV0 P/P9+ V$H83X0-JUKY7U8UPCWRN5QF4UADAH2-6RJ+945T4TUL5UHA7D7N$0QMNADESRYMVWNE7K*V7YMR8:MLHQNJN  V+PVJGCI1WH.N+3F-$2:32:.B2P4RT7W04. KP40MZIKYLW2K.G3RUUD-VF0OLPTYDRH9OOWB0UC3J4U*SR0BT9O:9C6VJXLT$OJKIFR24./SZ8Q:9U.MC3B1U*EHDT0CAMHUH*P/GVLTRX$H%WSCGBH$UAM8*4VV*8U7V*.1TPFOBVCDKBEGD33$Y0WL3QASDKJ3 BTN4VEVFSO%Y74 F6%4UL1.R6B5N598LI00.2K327-0Z$Q4UIWH0LD6OU4-52GWO8YLYR0DJJ2GNHSMBR9S*P%BAU51FQGD7C5111XGXC9%GU1C19NGO%C9F0%*BA$0M8BJKN:MF0TQMGTT.TX D971EQ69ZCQIV/99L/TXLD%W4 8LA:O.WANZ2R8B+HBPC0ZG2G*OJ2TM.0C1U+HJ7TH.SE/5USA45692DDOVMC5HGTQ%AH65P2*2O/O1IS:8EZDR-HHY4G9RV94I-AW*38S4DHEB*SCGZO2DSC%T5WT*DSAXBZ705EHQOSFZBIAAD/089295OH%9Q F6%23S69QL1T7+DPQGVTVO7N7TWSBGB9740T09.9PYKO7GGKTNDC3CBJMLH8T3U71LLUAMCGNLMGLNHB:CZL4F+55/8SDJ4W27R26XHLZ43DAMCL9357$VSDKQRN6K6FE9X:D3VI2:5ZUC30BFGCSYO2.2DWFM1O7+TI4CGZL25WK29E8S/RJLJ147CQT1RGG:D5RPN5I5E3FC/GM63AP2+ERI K4W8N-J$-8B+JG9HL%Q Q7$TRC6A*X2KGPUA4%BMJYN*147MRHGQSPUU8KPMM8ESB+QXEGVICMWKKCB BNG/AZAA/NUQP0BT8B.O:0UAJM.LNTQ1QHG %N/0CD3TBF2T8V1T06R6WGM:ECGNMZ5VO*2-$NNSFL3CIOLR7IQVL1JS1P2AHG0ZL2%OH087ZOT6AX8WGZHADIMVBSUN113RK2Z19QYMUT7+IEDW5XA3+PS/AFSTRI*IB%IHYTH0HJM7JRH8IIT$G77WVA0DZG1WH9%OILG0OJ/-G C3-IL3VI*356RD*E4O+9Y/77YRK789PM7NN-671D3MYP3M0$XFZ4RNH5+IE5 LUVE5IDQOF/%D0HEYJF-/U-264QNJ32AD7659244G/09+K:WONC98RBBXKDLUY71UORY%SEQR*DOS21JLV8$CH-4KMUP6E170:F8T.Q4004:906BRQ3+CSQXSWDOJ:HSR69%9 S29D1ZBLRJ46FN1.Q6-C.O572EZUDL$S.CJ996:MJTFTHIHI2BDC3G%AN6GJ01.JC/5PMJ8+ MU:FZYNBS7Y9NM 4U0V74MO5W58JQG1BL3YQS2YTLZ7481C7EOP89KDH0R5%VH+3J7R9GJXKH%U0TJOHX4CQT/M4QSK5BGU-VDCAAUB47J /QYGD%8WOAFXA5--AS*GTYL4ZO- LGRLZS8WXAPS5P3UR6LALCPH8$C156K8/SP.QQJEO*LKBJ+HK%TDB21:PVB5O*RS6Q0YMI7C3ERI412GMFI5ES4TSLSSH7 ELA.VZF82USDW2W4O*/D13WC:KD4LY1J6CKM-QHSJWILQ0H%FT.U33AQU.2538Q78*/R5B4WDHEB4ZLJEHT21TP311V0G O:*K9%00A5TEQYCD1 3R0O YTFYK9F7QFO2QL$0N/5LDDU4X65E58:0XN1I7INE5A%JPTLWOVS5VWOTGHL6Z7C*B*KMW4DCYP-H3YYIXP10FM4NLROJNK8RA2X/QDP9QTA5IPJ62HVEOHJRW20CG8D4I34XUC7CTTTOJNHCF756V0J6LC149C*0BX$KBZ4:OBLL4DFH2XLH%M088YR5X7U4R8HS4TGO/CAPPKF211GHQD2R3VP24H8W: LRK7*DO6.QN*I+92UNAZRLFU0ARO:UL4GIHKKOITUI6V*Q%LT54PRERO1U%ME% FKYMGVHQSKYEMGF57UCUTLUV03-8IP3TT8.BLJ27QQFP6H2W0VNFU/FE4HQVGA.V616DUFY%0O5HCMK/MHGQ6+0QJHG.BNIPL$-2PA7S*I.-JQZO/-832IT:O2:AGIKU8GA/Q7TBSXUIHEBTT:TI9ADL%R9+G:KDSZM.7L%NOFJNJ1RSINW+E300F.TRQ8SE8V6M.F9B/TWB4%+9/PRKX22HQX 6N%R6.4L3P8US09AKG9+J6XT0Q94XLV%65+BK+BDFGKDFPB-J6FHV0MT*EQ%81$SWRHSKLMP282S2XPE*L KG9HH+$JW8HO.AO26 W1X7QLYT4OTW5U1FB-NDB:Q6LFUHUT GWJR2M1M%2QLND71U.DU:SS0RCG54CAHG4CO9E*PLU1Y*O%:BG+167FTUFAQQ6DB2TF0S1E%1$88%JOEE3+D9ZDOCKBI-DW18B03S/IH0LAJJRKTC88M KRVEJI6PHC+ 50JH$*I6-A41PQV2+0E*-D%:10*QC:1XB310H0KD0WIE83/X9EOG9BMZJ3BKQ 6B XVNJC87K4QSZW2E/5*M6YU5/.VKGHXJQXVI0JJ9LBBLHM3W:D8-N38XI$ EN656IDI1JB8KIHRCVVR/MLXIA7GY21AA9/%8XELV:AA5E9E22/L3LCXT8/HRYY2Z$K*:1TGT8L6-VC9XO*I508GJ11O.77V4GYF1 2UZFZ53DTVNGEG6D3XQ6QD-U6RVNS:53FVS7V409-4T10DK2W1%CEK8R5PGQRX 33H8D*58 AFY644IR*CJAW+A8G3PEBU N3/XFUUQI%BX27M T- VP-F.+3LWOHTFID6W$S1WNXPGSIF06F1ZV:N08G6\"\n            },\n            \"gender\": [\n              {\n                \"language\": \"eng\",\n                \"value\": \"MLE\"\n              },\n              {\n                \"language\": \"hin\",\n                \"value\": \"MLE\"\n              },\n              {\n                \"language\": \"fra\",\n                \"value\": \"MLE\"\n              }\n            ],\n            \"id\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ==\",\n            \"email\": \"IdRepository_AddIdentity_AuthStatus_Vid_Valid_smoke_Pos@mosip.net\",\n            \"compressedFace\": \"data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABQADwDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCEF3607G2stH1OT/Vxk/nU8VtrEkoVouvvWftYL4dRvnm/eZLJe+VLtzUi6gAMlqzNYs5rNWkmeJHH8JcZ/KuZTxLFbyAXS5i7lRk1aqXV0hOKW7O4/tUBsbqka4nmXMQzVTw/rfgvVWWAyzLct08yHC/nmvSLPw5YJa77cxyD+8hBH6VPvt3Wg1Y84e21SXhIifzpn9la3/zw/U16jFarB0qxvqr1OrFd9Dm4LR4vuLUOv38mkaLJeKcTAhV+prei2jrWJ44svtvh5UjGT9piLf7ueaq/NLUOljltD8MN40xqeqqfNPtnrWZ4v8D2NhcPHbrzzj5a6iTxbZ+GVNpbTYQfhWDe+K7fVp/PeXND5ErdTSKs1oeeSaK1vEcAq4rtPht41utN1aLRbyUi1dSBk/xdB/Os3Vb+1ZyUfNc3DBNPr9lcQLnFxHz/AMCFZxbT12KnCL1R9TLCWO1xzUn2H2ojM33pRiSpvOuPT9a0uYcyMmKGL+Osm/Mr6mLYD/RDnJq75+/vVO+ult4yzNgVME27FxaTbZxPjDwDb3908tlJ8/OA2APzrOg8BDT/AArJNdKn2pcY2EMOh71vXetlrjyy+Iz1NYWuazqkVs8VnLEbPvmUA/lWslFdDSNmjh10ySX7y1s6DCtnqtqk3yxiRSPrkYqrZ6jI2Nxrp9B0r+29ThTbu2kSfkc1zt6WJkktT3COdrgCVutTeZVW2+S3xTt1U2cyi7s5m1dWAya868c+JJ7bX49Ojb90clhnuDXoaCG2/wBYcYrx/wCIUcbeIxdxHI3FQfcmrj7zsi5STi13NON4rpME5kPasvUrLywQUGavzWEtroFrewL/AKV5eX+tcy+sajcRk3Iw/wBaTbta5rGTtdiwosbgNwK9a+Flq6pdX5H3TsjP+yRzXibXU7P83T612/w+8f8A9nSy6TdyMkbOBGewA459KiEfesObUonuplCrgGovO96pQahaXAxFOkme6MCKs7Upqxje54xc+Lb67J+bOfeub1OeW8mUT/dVw34g0WPQUuo969ZcvI0lucNNtvU7XT5Jb7SNw5Q45rl9YsljdiBXe+BLWOfwt83t/I0mp6DaSbsj9K5J0bu6PSjLQ8dnO3NZs0u5sE8V0/iYaZp872yl/P7YTj8649ySeaz9mkiJTurG3pPiHVNHkU2d7KsS/wDLMHANdR/wtTW/Qf8AfZrgYvuVJR7R9Dmluf/Z\"\n          },\n          \"issuer\": \"did:web:injicertify-mosipid.dev-int-inji.mosip.net\",\n          \"id\": \"https://mosip.io/credential/b7b92027-1368-4bc3-b69d-e0b88ccfd7f6\",\n          \"type\": [\n            \"VerifiableCredential\",\n            \"MOSIPVerifiableCredential\"\n          ],\n          \"issuanceDate\": \"2026-06-15T14:11:31.180Z\"\n        }\n      ],\n      \"type\": [\n        \"VerifiablePresentation\"\n      ],\n      \"id\": \"urn:uuid:da9402e9-42cd-44b3-9987-7cf479cb8949\",\n      \"@context\": [\n        \"https://www.w3.org/2018/credentials/v1\",\n        \"https://w3id.org/security/suites/jws-2020/v1\"\n      ]\n    }\n  ]\n}",
                       "type": "text"
                     },
                     {
                       "key": "state",
-                      "value": "{{reqId_VPSession_Without_Response_Code}}",
+                      "value": "{{1_3_reqId}}",
                       "type": "text"
                     },
                     {
@@ -3804,7 +1689,7 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-request/{{reqIdForOpenID4VP}}/status",
+                  "raw": "{{base_url}}/v1/verify/vp-request/{{1_3_reqId}}/status",
                   "host": [
                     "{{base_url}}"
                   ],
@@ -3812,7 +1697,7 @@
                     "v1",
                     "verify",
                     "vp-request",
-                    "{{reqIdForOpenID4VP}}",
+                    "{{1_3_reqId}}",
                     "status"
                   ]
                 }
@@ -3820,7 +1705,45 @@
               "response": []
             },
             {
-              "name": "vp session results without response_code",
+              "name": "vp results",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{1_3_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-result",
+                    "{{1_3_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results v2",
               "event": [
                 {
                   "listen": "test",
@@ -3841,13 +1764,7 @@
                   "type": "noauth"
                 },
                 "method": "POST",
-                "header": [
-                  {
-                    "key": "Cookie",
-                    "value": "{{txnId_VPSession_Without_Response_Code}}",
-                    "type": "text"
-                  }
-                ],
+                "header": [],
                 "body": {
                   "mode": "raw",
                   "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
@@ -3858,14 +1775,16 @@
                   }
                 },
                 "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-session-results",
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{1_3_txnId}}",
                   "host": [
                     "{{base_url}}"
                   ],
                   "path": [
                     "v1",
                     "verify",
-                    "vp-session-results"
+                    "v2",
+                    "vp-results",
+                    "{{1_3_txnId}}"
                   ]
                 }
               },
@@ -3874,22 +1793,18 @@
           ]
         },
         {
-          "name": "5.1. invalid nonce or client-id",
+          "name": "1.4. ldp_vp - expired - require_cryptographic_holder_binding false",
           "item": [
             {
-              "name": "vp request with invalid nonce",
+              "name": "vp request using dcql",
               "event": [
                 {
                   "listen": "test",
                   "script": {
                     "exec": [
                       "var responseJson = pm.response.json();",
-                      "",
-                      "var txnId = responseJson.transactionId;",
-                      "var encodedTxnId = btoa(txnId);",
-                      "",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('1_4_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('1_4_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -3909,7 +1824,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\r\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ=\",\r\n    \"responseCodeValidationRequired\": true,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"id_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net\",\r\n    \"nonce\": \"yMRlSK2ZT31GdWbedhk4hA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n            \"credentials\": [\r\n            {\r\n                \"id\": \"age_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false,\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"male_gender\",\r\n                        \"path\": [\r\n                            \"gender\",\r\n                            null,\r\n                            \"value\"\r\n                        ],\r\n                        \"values\": [\"MLE\"]\r\n                    },\r\n                    {\r\n                        \"id\": \"full_name_eng\",\r\n                        \"path\": [\r\n                            \"fullName\",\r\n                            0,\r\n                            \"language\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"male_gender\",\r\n                         \"full_name_eng\"\r\n                    ],\r\n                    [\r\n                        \"full_name_eng\"\r\n                    ]\r\n                ]\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"age_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -3932,252 +1847,7 @@
               "response": []
             },
             {
-              "name": "vp submission invalid nonce",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "",
-                      "pm.test(\"Status code is 400\", function () {",
-                      "    pm.response.to.have.status(400);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"id_credential_query\":[{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"type\":[\"VerifiablePresentation\"],\"verifiableCredential\":[{\"issuanceDate\":\"2025-12-23T10:27:09.133Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"value\":\"MLE\",\"language\":\"eng\"}],\"city\":[{\"value\":\"TEST_CITYeng\",\"language\":\"eng\"}],\"phone\":\"2261640506\",\"fullName\":[{\"value\":\"TEST_FULLNAMEeng\",\"language\":\"eng\"}],\"addressLine1\":[{\"value\":\"TEST_ADDRESSLINE1eng\",\"language\":\"eng\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\"UIN\":\"2042351307\",\"email\":\"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"},\"proof\":{\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"https://api.released.mosip.net/.well-known/ida-public-key.json\",\"type\":\"RsaSignature2018\",\"created\":\"2025-12-23T10:27:09Z\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"},\"id\":\"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\"type\":[\"MOSIPVerifiableCredential\",\"VerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",{\"sec\":\"https://w3id.org/security#\"}],\"issuer\":\"https://api.released.mosip.net/.well-known/ida-controller.json\"}],\"id\":\"urn:uuid:b978c646-8c07-4c1f-9598-f3e5f195d342\",\"holder\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\",\"proof\":{\"type\":\"JsonWebSignature2020\",\"created\":\"2025-12-23T16:02:51Z\",\"challenge\":\"oNjl1LmAXj6pqygwQnMBFQ==\",\"domain\":\"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\"jws\":\"eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..QsdZRqx7X8HcuDD8R55FCpeuGMVLiMZnmZYoKpZ_B1r5FH687Xy15XMwH56gl8-6sGrwU9pdQctdN0afx_dkAg\",\"proofPurpose\":\"authentication\",\"verificationMethod\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\"}}]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp request with invalid clientId",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "",
-                      "var txnId = responseJson.transactionId;",
-                      "var encodedTxnId = btoa(txnId);",
-                      "",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n  \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-respons\",\r\n  \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\r\n  \"responseCodeValidationRequired\": true,\r\n   \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"id_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp submission invalid clientId",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "",
-                      "pm.test(\"Status code is 400\", function () {",
-                      "    pm.response.to.have.status(400);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "vp_token",
-                      "value": "{\"id_credential_query\":[{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"type\":[\"VerifiablePresentation\"],\"verifiableCredential\":[{\"issuanceDate\":\"2025-12-23T10:27:09.133Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"value\":\"MLE\",\"language\":\"eng\"}],\"city\":[{\"value\":\"TEST_CITYeng\",\"language\":\"eng\"}],\"phone\":\"2261640506\",\"fullName\":[{\"value\":\"TEST_FULLNAMEeng\",\"language\":\"eng\"}],\"addressLine1\":[{\"value\":\"TEST_ADDRESSLINE1eng\",\"language\":\"eng\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\"UIN\":\"2042351307\",\"email\":\"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"},\"proof\":{\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"https://api.released.mosip.net/.well-known/ida-public-key.json\",\"type\":\"RsaSignature2018\",\"created\":\"2025-12-23T10:27:09Z\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"},\"id\":\"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\"type\":[\"MOSIPVerifiableCredential\",\"VerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",{\"sec\":\"https://w3id.org/security#\"}],\"issuer\":\"https://api.released.mosip.net/.well-known/ida-controller.json\"}],\"id\":\"urn:uuid:b978c646-8c07-4c1f-9598-f3e5f195d342\",\"holder\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\",\"proof\":{\"type\":\"JsonWebSignature2020\",\"created\":\"2025-12-23T16:02:51Z\",\"challenge\":\"oNjl1LmAXj6pqygwQnMBFQ==\",\"domain\":\"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\"jws\":\"eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..QsdZRqx7X8HcuDD8R55FCpeuGMVLiMZnmZYoKpZ_B1r5FH687Xy15XMwH56gl8-6sGrwU9pdQctdN0afx_dkAg\",\"proofPurpose\":\"authentication\",\"verificationMethod\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\"}}]}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
-                      "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-submission",
-                    "direct-post"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "4.1. invalid holder binding",
-          "item": [
-            {
-              "name": "vp session request using dcql",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "var responseJson = pm.response.json();",
-                      "pm.collectionVariables.set('txnIdForOpenID4VP', responseJson.transactionId);",
-                      "pm.collectionVariables.set('reqIdForOpenID4VP', responseJson.requestId);",
-                      "",
-                      "pm.test(\"Status code is 201\", function () {",
-                      "    pm.response.to.have.status(201);",
-                      "});"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {},
-                    "requests": {}
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\r\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"id_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                        \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                        \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-session-request",
-                  "host": [
-                    "{{base_url}}"
-                  ],
-                  "path": [
-                    "v1",
-                    "verify",
-                    "v2",
-                    "vp-session-request"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "vp submission invalid holder binding",
+              "name": "vp submission expired",
               "event": [
                 {
                   "listen": "test",
@@ -4204,12 +1874,12 @@
                   "urlencoded": [
                     {
                       "key": "vp_token",
-                      "value": "{\"id_credential_query\":[{\n  \"@context\": [\n    \"https://www.w3.org/2018/credentials/v1\",\n    \"https://w3id.org/security/suites/jws-2020/v1\"\n  ],\n  \"type\": [\n    \"VerifiablePresentation\"\n  ],\n  \"verifiableCredential\": [\n    {\n      \"issuanceDate\": \"2025-12-23T10:27:09.133Z\",\n      \"credentialSubject\": {\n        \"face\": \"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\n        \"gender\": [\n          {\n            \"value\": \"MLE\",\n            \"language\": \"eng\"\n          }\n        ],\n        \"city\": [\n          {\n            \"value\": \"TEST_CITYeng\",\n            \"language\": \"eng\"\n          }\n        ],\n        \"phone\": \"2261640506\",\n        \"fullName\": [\n          {\n            \"value\": \"TEST_FULLNAMEeng\",\n            \"language\": \"eng\"\n          }\n        ],\n        \"addressLine1\": [\n          {\n            \"value\": \"TEST_ADDRESSLINE1eng\",\n            \"language\": \"eng\"\n          }\n        ],\n        \"dateOfBirth\": \"1992/04/15\",\n        \"id\": \"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\n        \"UIN\": \"2042351307\",\n        \"email\": \"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"\n      },\n      \"proof\": {\n        \"proofPurpose\": \"assertionMethod\",\n        \"verificationMethod\": \"https://api.released.mosip.net/.well-known/ida-public-key.json\",\n        \"type\": \"RsaSignature2018\",\n        \"created\": \"2025-12-23T10:27:09Z\",\n        \"jws\": \"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"\n      },\n      \"id\": \"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\n      \"type\": [\n        \"MOSIPVerifiableCredential\",\n        \"VerifiableCredential\"\n      ],\n      \"@context\": [\n        \"https://www.w3.org/2018/credentials/v1\",\n        \"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",\n        {\n          \"sec\": \"https://w3id.org/security#\"\n        }\n      ],\n      \"issuer\": \"https://api.released.mosip.net/.well-known/ida-controller.json\"\n    }\n  ],\n  \"id\": \"urn:uuid:b978c646-8c07-4c1f-9598-f3e5f195d342\",\n  \"holder\": \"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\",\n  \"proof\": {\n    \"type\": \"JsonWebSignature2020\",\n    \"created\": \"2025-12-23T16:02:51Z\",\n    \"challenge\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"domain\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"jws\": \"eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..QsdZRqx7X8HcuDD8R55FCpeuGMVLiMZnmZYoKpZ_B1r5FH687Xy15XMwH56gl8-6sGrwU9pdQctdN0afx_dkAg\",\n    \"proofPurpose\": \"authentication\",\n    \"verificationMethod\": \"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\"\n  }\n}]}",
+                      "value": "{\"age_credential_query\":[{\"issuanceDate\":\"2026-03-27T10:34:33.914Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"language\":\"eng\",\"value\":\"MLE\"},{\"language\":\"hin\",\"value\":\"MLE\"},{\"language\":\"fra\",\"value\":\"MLE\"}],\"compressedFace\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABQADwDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCEF3607G2stH1OT/Vxk/nU8VtrEkoVouvvWftYL4dRvnm/eZLJe+VLtzUi6gAMlqzNYs5rNWkmeJHH8JcZ/KuZTxLFbyAXS5i7lRk1aqXV0hOKW7O4/tUBsbqka4nmXMQzVTw/rfgvVWWAyzLct08yHC/nmvSLPw5YJa77cxyD+8hBH6VPvt3Wg1Y84e21SXhIifzpn9la3/zw/U16jFarB0qxvqr1OrFd9Dm4LR4vuLUOv38mkaLJeKcTAhV+prei2jrWJ44svtvh5UjGT9piLf7ueaq/NLUOljltD8MN40xqeqqfNPtnrWZ4v8D2NhcPHbrzzj5a6iTxbZ+GVNpbTYQfhWDe+K7fVp/PeXND5ErdTSKs1oeeSaK1vEcAq4rtPht41utN1aLRbyUi1dSBk/xdB/Os3Vb+1ZyUfNc3DBNPr9lcQLnFxHz/AMCFZxbT12KnCL1R9TLCWO1xzUn2H2ojM33pRiSpvOuPT9a0uYcyMmKGL+Osm/Mr6mLYD/RDnJq75+/vVO+ult4yzNgVME27FxaTbZxPjDwDb3908tlJ8/OA2APzrOg8BDT/AArJNdKn2pcY2EMOh71vXetlrjyy+Iz1NYWuazqkVs8VnLEbPvmUA/lWslFdDSNmjh10ySX7y1s6DCtnqtqk3yxiRSPrkYqrZ6jI2Nxrp9B0r+29ThTbu2kSfkc1zt6WJkktT3COdrgCVutTeZVW2+S3xTt1U2cyi7s5m1dWAya868c+JJ7bX49Ojb90clhnuDXoaCG2/wBYcYrx/wCIUcbeIxdxHI3FQfcmrj7zsi5STi13NON4rpME5kPasvUrLywQUGavzWEtroFrewL/AKV5eX+tcy+sajcRk3Iw/wBaTbta5rGTtdiwosbgNwK9a+Flq6pdX5H3TsjP+yRzXibXU7P83T612/w+8f8A9nSy6TdyMkbOBGewA459KiEfesObUonuplCrgGovO96pQahaXAxFOkme6MCKs7Upqxje54xc+Lb67J+bOfeub1OeW8mUT/dVw34g0WPQUuo969ZcvI0lucNNtvU7XT5Jb7SNw5Q45rl9YsljdiBXe+BLWOfwt83t/I0mp6DaSbsj9K5J0bu6PSjLQ8dnO3NZs0u5sE8V0/iYaZp872yl/P7YTj8649ySeaz9mkiJTurG3pPiHVNHkU2d7KsS/wDLMHANdR/wtTW/Qf8AfZrgYvuVJR7R9Dmluf/Z\",\"phone\":\"7367102638\",\"fullName\":[{\"language\":\"eng\",\"value\":\"TEST_FULLNAMEeng\"},{\"language\":\"hin\",\"value\":\"TEST_FULLNAMEhin\"},{\"language\":\"fra\",\"value\":\"TEST_FULLNAMEfra\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6ImNHSjljZnVaY1RTZVFfSkR4anRJaEJ5MlF1ZUtKZWtxMU9iU01DQmdWaDAiLCJhbGciOiJFZDI1NTE5In0=\",\"UIN\":\"3920190347\",\"claim169\":{\"identityQRCode\":\"NCF4:OWBBPP3F:H37MMC2Y48.6H-2S6612S3T3MC 3QM3+NV/-KCFI3IO-THZL0PXMYHFEPJ1$LOOQ8HP7CU*GBEWH55MRNRO.7-MEV2ITVNSRE:XRO:TT7LMFV*ITX/L WOU-JL0QKXDH S02S4O3YNVF%PIQJ/4NN873KFOM3-NEUEDV0FC:6//EW S4+DNC7M.Q*IET7VN06D+MO4A*9F4SUBCFEJVHAO 8TF7TMKIG.F5W6CZR6JN.5G6ZUSDSQ:1V SIBS7*JXYPH02YJMH-9KZUJ8MM:T87K0AV+W9ZSV%0N7CPK U6A6-OD$QVW8TW4T*3QBKUXEF4IV.5N5SM08B6JPS3WHUVH6EB.SKJ23F6/8SS5S2ZKJB6N:91BJTBPLPP%BH1Y98JTTDS8SO7WSKLIUSC+RNZXNWW7SKR9PI/%PVT28P6NEB1XLN/FM5S86GG2RE.O-7S0/40UQKCJB0F-NTK+8S5T68PHLC87B:KUV L1HB0U6:PE4SJB1VA1R4ZLO33V+LI4N2NMHUI8QIIMJ/DA +PK%95$UI7QU38C5P8YT5/3C2GXWCRF6-3EYDR4PDTHE+TE$3BDHRY$I*.3%HKCT4:F0A$SNC6XQ5AP6425ZNHGTLZ:LKM530C-IF8EVPEW6144+5LYH418P0S:APHF4XWTIIE:$H5KD*A7-+8Z/P 1QZPGJ+F91F 3UY4EWV1443%N53YH9CEM5P*9AMBV9GVTZH7YGPAI:*ST%RGSPT.1TJC7R0PUIA7PRWS4+AF5FR2RYXUTXMNYEE14Z6OL2RB-5D9JI+65KVW7QAX1RQ1L48W:EOTC%HT.GKP92:ESK+800W551 YFLW1.V3LRRO4PMKFZ48LVHXSKNERX*UKLEV/4J36 P4XQIQBCME4:9BJG1A 63THA$3S2CF:4$NAAAD$HMTZS5ASOMH91ATL75CA2Y958VMH4KCG7J6%F8/DLI35V 3I5JTEO.28/WG0*P-TKF8RA823F4LK0L%H4T6I0KIO1B.8U8F25WG18IUIX6W9:VTO6MDW5:V/5CFIM8O55HAZXVE2G:*7SCWK5BI0D:OQ GUEXKC7F1RP.JEJHS3DF-V2*OGWVLW664A5 0P/JPS2J++14/8:EH3CQ%QU$A8CFPMQSQ$78K3.7QVRC9E2U ECFVMB8-%F.Z6PYB7Q3V PJRJNKO-844USZYG*EMMEO$TC*80.F6Q$FEPTZAW.0Q2 8D70APMYTI$$O3CB.VLSE6GNBO0FBGMUWKH:RSAL$MI2:KR.3TWVD3JLZLZAL1PBMESI%RFB2/$F9OSLWSUWBOJV$41P/HO.Q$MCUZNUH2P*UT-U$0E2LL 0IGPKS46: 5UA422SJ3T*GOE4P*.B68G8*Q.3U66RB4UWQ7GSL7%AHPJHX25RPIUVU.4SGVLIC2*59BRO 7$ZAOCOJV7RY11ON/AQ0406AT%GQGMR1+MNRE+W1PCSU7551Q RAFH8YY74$OUXAX8LLCOX NBV4$/8AJP2+6EJ5U1A+XGQ%LIMCC-H6890AHOF1W1RAKMPRGKNQZFUV3A0WK4.89YFN%R64HYWA*FGKVB/XKCZE4-2H113R4Y QB.F6$JCP3OZGPFR3+GQ OLLR UQX81SPHUIGK:KJQNG/KAX1TLMN45M/HT51%XP4-AN91HRGE/MPQFXN4EWPGRERZR$K0P07BNP.X5TACJGITNOCKQ$GVQV5+$4DI4FHAR$CP2DP76R*9S5D*/JV*87KVU9S.SL:DAO.0/J5VES*QNY%9O44MOH2PHU98 Y0J-38$1KU8XGH8J8/22BFRU F9LMO:O%-DSM78GF2ZV6XUD8JPYHOKK/YL0:58$KPNF.54DTO7TL$ES%ODC-DZPL+Y2TM1P*C$A6A J*VQJ*FSRD+6GGY43TO+4P5870LF*9Q.F8UWB29A2NJV 615O%/0C%EA*48NKW70-46.HHMVV$992BLZ24Y8OI Q$CR%+KO$E5TRO7O+-BGF1PV2XKS-J51LUMVLBF5*KQY-Q:RHIYNTJLPHRPCI2OG.AT2NVT%EA%RWJ591L67DWI3ILGU-7E16DCNH90.YK 2HE$S*$O%:BNQB3FF-AFEZ19RTA6G5CI467B:O8162XRY08MC5MKLN*K9BLA-E0%4RTT KS ONQBPC$UF-GN-1I7A 3FG11COKF89R3T0H74A7TH8F60NA6UNTHKOQOPUVE5SRF-0BFU.RVNFD/1Q$AE%LDHZ5$GD:M7K:P9G1Z60OP88ZSSLHIDT2STR8WXX7NLFYNLO.1X6JTYDNGBTUUL*8G*K.TO8XD1H533L/FQI$OK:MPPQ:XAZF6G O.*J6%4EX8J44/59.499ORDE77EMGTSX0IK/NFV9VJGSAB*$I1JL$JHB7RVAH0MCBF58 D0229THYTN1JQ8B9U9EBVAWBLJLG%OKPS8E$FXFPF3GJRDA:H+469-MHW43+OB*Q1TT4D8ECEISTVYKY7D:UVMWH%X66I7RHM$%6P V/YJS0CHZ54J42BL9$LBC1+FB$F5JD8J72C3HQFIUQLGY1T7S2A4RHGY/B414EKS:BC$FW*Q933K5B0HJKXDLEMKNU1+UM.24Q*51J55U0P:HM C:5L$FEMA2%XSUGE4W2FBLYBK6:UPCRE+VGWB3OF:$S D3/7NPFCXHBY*D:JLS8EU.DG1VM.DJ*JCCOCYN+7AUEIQXT:LIXZVRGPWXQ36VV-OCWEN.PT275919GE*CN%*QKJA6U9RFGTEP%-F2H9AFTTF3-ETQKEEBTSOKFPD0.J3B2JHNFF43JDHY8PBNUG6UULZ34HQSA/4GKCPY2DK1HQ8RWM1H7ZMFYYVR7RLIB3*EG:JJWFBDCV4NJJ8*%GE2MQI8QOBFJNQ2V:H95ZIR996HAUUMKH0*GEL5BJP8CV3J7K ZM23J-:J8P83M8W7ALAE73PLLID6636R1N3N4AP+GM$C4ILP%4:E7322DHLBX3G*PPCJ6N90G42.KKZAVJM3:O+UJARBKUOR+EPN8G5PJJKMHB4+K-*8BPAUFKLXL.*8AUE /AZ+7LEJSCTCDNS$8BUH9 P1N9-08KJCK%MYZK43L6/AAJCSFW7FKZ*HRRPXNNYP2X*M2Q9K9Q9VD:+F/IBQJ9IFWY21AA9/%8XELV:AA5E9E22/L3LCXT8/HRYY2Z$K*:1TGT8L6-VC9XO*I508GJ11O.77V4GYF1 2UZFZ53DTVNGEG6D3XQ6QD-U6/VN0CRR*6-.MV1EC*3N28.-AD-F5:AI%G1ZR%+5+BP04F-9QUEJR0K-XHW5E-+37QNJEUKFVGUG86F6DU CVF*LPP9/N3IDKS68*8J6IJ$HQ:129F289KV7TW40E%6.4\"},\"email\":\"IdRepository_AddIdentity_AuthStatus_Vid_Valid_smoke_Pos@mosip.net\"},\"id\":\"https://mosip.io/credential/752bf960-c9d7-4bab-94bc-ca4af28016c2\",\"type\":[\"VerifiableCredential\",\"MOSIPVerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://inji.github.io/inji-config/contexts/mosip-identity-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuer\":\"did:web:inji.github.io:inji-config:dev-int-inji:mosipid-identity\",\"expirationDate\":\"2028-03-26T10:34:33.914Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2026-03-27T10:34:33Z\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:web:inji.github.io:inji-config:dev-int-inji:mosipid-identity#7TmkqqmmpxilQ_H54iWD1Uea90JTiup_p9mUi90UMvA\",\"proofValue\":\"z4jFVQRdQq5taLtmByFUxHDStQxbFefT9M964ZK6VFVKKPNa5cztzQKxMHBTDcEhS6mQMSnv4Vf2YBFcTvXBooqTR\"}}]}",
                       "type": "text"
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForOpenID4VP}}",
+                      "value": "{{1_4_reqId}}",
                       "type": "text"
                     },
                     {
@@ -4266,7 +1936,7 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{base_url}}/v1/verify/vp-result/{{txnIdForOpenID4VP}}",
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{1_4_txnId}}",
                   "host": [
                     "{{base_url}}"
                   ],
@@ -4274,14 +1944,14 @@
                     "v1",
                     "verify",
                     "vp-result",
-                    "{{txnIdForOpenID4VP}}"
+                    "{{1_4_txnId}}"
                   ]
                 }
               },
               "response": []
             },
             {
-              "name": "vp results V2",
+              "name": "vp results v2",
               "event": [
                 {
                   "listen": "test",
@@ -4313,7 +1983,7 @@
                   }
                 },
                 "url": {
-                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{txnIdForOpenID4VP}}",
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{1_4_txnId}}",
                   "host": [
                     "{{base_url}}"
                   ],
@@ -4322,7 +1992,2535 @@
                     "verify",
                     "v2",
                     "vp-results",
-                    "{{txnIdForOpenID4VP}}"
+                    "{{1_4_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "1.5. ldp_vp - invalid signature - require_cryptographic_holder_binding false",
+          "item": [
+            {
+              "name": "vp request using dcql",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "pm.collectionVariables.set('1_5_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('1_5_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net\",\r\n    \"nonce\": \"yMRlSK2ZT31GdWbedhk4hA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"age_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"MockVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false,\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"male_gender\",\r\n                        \"path\": [\r\n                            \"gender\",\r\n                            null,\r\n                            \"value\"\r\n                        ],\r\n                        \"values\": [\r\n                            \"Male\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"full_name_eng\",\r\n                        \"path\": [\r\n                            \"fullName\",\r\n                             null,\r\n                            \"language\"\r\n                        ],\r\n                        \"values\": [\r\n                            \"eng\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"male_gender\",\r\n                        \"full_name_eng\"\r\n                    ],\r\n                    [\r\n                        \"full_name_eng\"\r\n                    ]\r\n                ]\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"age_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp submission invalid signature",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\"age_credential_query\":[{\"credentialSubject\":{\"VID\":9876543210,\"gender\":[{\"language\":\"eng\",\"value\":\"Male\"},{\"language\":\"fra\",\"value\":\"Mâle\"},{\"language\":\"ara\",\"value\":\"ذكر\"}],\"province\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"phone\":\"+919427357934\",\"postalCode\":45009,\"fullName\":[{\"language\":\"fra\",\"value\":\"Siddharth K Mansour\"},{\"language\":\"ara\",\"value\":\"تتگلدكنسَزقهِقِفل دسييسيكدكنوڤو\"},{\"language\":\"eng\",\"value\":\"Siddharth K Mansour\"}],\"dateOfBirth\":\"1987/11/25\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\",\"UIN\":9876543210,\"region\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"email\":\"siddhartha.km@gmail.com\"},\"validUntil\":\"2028-01-08T07:19:56.385Z\",\"validFrom\":\"2026-01-08T07:19:56.385Z\",\"id\":\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\",\"type\":[\"VerifiableCredential\",\"MockVerifiableCredential\"],\"@context\":[\"https://www.w3.org/ns/credentials/v2\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuer\":\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\",\"credentialStatus\":{\"statusPurpose\":\"revocation\",\"statusListIndex\":\"94010\",\"id\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\",\"type\":\"BitstringStatusListEntry\",\"statusListCredential\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\"},\"proof\":{\"verificationMethod\":\"did:web:mosip.github.io:inji-config:qa-inji1:landregistry#UHNnpAY2hEkSnXqkc3aS07EgTEaw9WC64kpO3jvP9X0\",\"created\":\"2025-11-24T07:37:30Z\",\"type\":\"Ed25519Signature2020\",\"proofPurpose\":\"assertionMethod\",\"proofValue\":\"z5gfKobfm77qMGgs41LDkoSjZdS7fTx19runRBxPSckQUfCxMgbmnF9SiGwgJrkuzx1yYqdvkfW7u69v5cMc3ePCp\"}}]}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{1_5_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{1_5_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-result",
+                    "{{1_5_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results v2",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{1_5_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-results",
+                    "{{1_5_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "1.6. ldp_vp - revoked - require_cryptographic_holder_binding false",
+          "item": [
+            {
+              "name": "vp request using dcql",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "pm.collectionVariables.set('1_6_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('1_6_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net\",\r\n    \"nonce\": \"yMRlSK2ZT31GdWbedhk4hA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"age_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                        \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                        \"https://example.org/credentials#MockVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false\r\n            }    \r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp submission status check revoked",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\"age_credential_query\":[{\"credentialSubject\":{\"VID\":9876543210,\"gender\":[{\"language\":\"eng\",\"value\":\"Male\"},{\"language\":\"fra\",\"value\":\"Mâle\"},{\"language\":\"ara\",\"value\":\"ذكر\"}],\"province\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"phone\":\"+919427357934\",\"postalCode\":45009,\"fullName\":[{\"language\":\"fra\",\"value\":\"Siddharth K Mansour\"},{\"language\":\"ara\",\"value\":\"تتگلدكنسَزقهِقِفل دسييسيكدكنوڤو\"},{\"language\":\"eng\",\"value\":\"Siddharth K Mansour\"}],\"dateOfBirth\":\"1987/11/25\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\",\"UIN\":9876543210,\"region\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"email\":\"siddhartha.km@gmail.com\"},\"validUntil\":\"2028-01-08T07:19:56.385Z\",\"validFrom\":\"2026-01-08T07:19:56.385Z\",\"id\":\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\",\"type\":[\"VerifiableCredential\",\"MockVerifiableCredential\"],\"@context\":[\"https://www.w3.org/ns/credentials/v2\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuer\":\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\",\"credentialStatus\":{\"statusPurpose\":\"revocation\",\"statusListIndex\":\"94010\",\"id\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\",\"type\":\"BitstringStatusListEntry\",\"statusListCredential\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\"},\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2026-01-08T07:19:56Z\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity#BF6EnRlmWN2x2T0HsTBbDtbci_dD2qYPdtxlVpv2Lz8\",\"proofValue\":\"z2jBgb8JmCH3b5LyfeqF1gFsgBTmQcr18hTD98SDGhoL3Nrr8vwjWw7iGxVECYz9yD5SWCrPP83YAQ81yH2WvDY1b\"}}]}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{1_6_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{1_6_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-result",
+                    "{{1_6_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results v2",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{1_6_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-results",
+                    "{{1_6_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "1.7. ldp_vp - status check error - require_cryptographic_holder_binding false",
+          "item": [
+            {
+              "name": "vp request using dcql",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "pm.collectionVariables.set('1_7_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('1_7_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net\",\r\n    \"nonce\": \"yMRlSK2ZT31GdWbedhk4hA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n           {\r\n                \"id\": \"age_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                        \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                        \"https://example.org/credentials#FarmerCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false\r\n            } \r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp submission status check error",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\"age_credential_query\":[{\"credentialSubject\":{\"gender\":\"Male\",\"primaryCropType\":\"Maize\",\"mobileNumber\":\"9876543210\",\"postalCode\":\"453000\",\"landArea\":\"3 hectares\",\"fullName\":\"John Doe\",\"secondaryCropType\":\"Rice\",\"dateOfBirth\":\"25-05-1990\",\"face\":\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAFCAYAAABW1IzHAAAAHklEQVQokWNgGPaAkZHxPyMj439sYrSQo51PBgsAALa0ECF30JSdAAAAAElFTkSuQmCC\",\"farmerID\":\"987654321\",\"villageOrTown\":\"Koramangala\",\"district\":\"Bangalore\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6Iml3Qkl1Q2QzaFU1NlBWM3VTc3gzekhMc1E4SXdYckdHdmh6YkE1VlJuQkEiLCJhbGciOiJSUzI1NiIsIm4iOiJtMWlMQ0prNzA5VkpIbUF2MURsWUxsblA0UDEtLXFfU3Q3aVo3WjhWbXk0d0Mxb2FTQWxXdjFXZjlKQXg2YmQ3OXdMbDhINEkwa25GeG9FbkktTUhvOUtGRXpFcGdJNXZIUHY2X0M2dWI4RmUwaXphRVFXTlY3VEpVRG54MVZ5OU5UZS15ekFVd2dfWk91Y0pFb3hyQW54VXM5OFcyTWpyUmtZdHVQcTlKRUxVTzRJM0wxX1B5S21hRG8zN0xCR3NVamhLVmQ0X0VzTkVPQ3AwQTZwbnBaUUd1S1RteXVhMUVYSDhLWUVTSEZ4alA4NGVCaGk0YmZPSWMwQjQ2VlZrVG81WG9TeUtnRi1xemRyTGFQRGJwZGxBaVNKMEJ5Vk5jaUE3Z2ctWEJLQkV0QVd1b19EQ3pYZUsxREJKT2txMXlkWEJzeWdjeGtpVmdobnFtUTFsVHcifQ==\",\"state\":\"Karnataka\",\"landOwnershipType\":\"Owner\"},\"validUntil\":\"2027-10-09T03:08:19.711Z\",\"validFrom\":\"2025-10-09T03:08:19.711Z\",\"type\":[\"VerifiableCredential\",\"FarmerCredential\"],\"@context\":[\"https://www.w3.org/ns/credentials/v2\",\"https://piyush7034.github.io/my-files/farmer.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuer\":\"did:web:piyush7034.github.io:my-files:sample-ed25519\",\"credentialStatus\":{\"statusPurpose\":\"revocation\",\"statusListIndex\":\"7\",\"id\":\"http://localhost:8090/v1/certify/credentials/status-list/649d3d36-2719-42eb-9f00-ac479a906059#7\",\"type\":\"BitstringStatusListEntry\",\"statusListCredential\":\"http://localhost:8090/v1/certify/credentials/status-list/649d3d36-2719-42eb-9f00-ac479a906059\"},\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2025-10-08T21:38:19Z\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:web:piyush7034.github.io:my-files:sample-ed25519#LYs95rEHKsqm1_TIFJxffLUXHZL1rM_h-UuwRi6PtN4\",\"proofValue\":\"z5Z3Rj9rhV5b6whiq4EgZaD8gmtsBtfMEqwNXAgasCxtBRCpc35DkiGFyRfy8NYDtXBDX6RjAUpWfgNGn94t2ywgm\"}}]}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{1_7_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 500\", function () {",
+                      "    pm.response.to.have.status(500);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{1_7_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-result",
+                    "{{1_7_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results v2",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{1_7_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-results",
+                    "{{1_7_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "1.8. sd-jwt - valid signature - dcql request",
+          "item": [
+            {
+              "name": "vp request using dcql",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "pm.collectionVariables.set('1_8_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('1_8_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net\",\r\n    \"nonce\": \"yMRlSK2ZT31GdWbedhk4hA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"vc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"eu.europa.ec.eudi.msisdn.1\"\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false,\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"registered_family_name\",\r\n                        \"path\": [\r\n                            \"registered_family_name\"\r\n                        ],\r\n                        \"values\": [\"Musterman\"]\r\n                    },\r\n                    {\r\n                        \"id\": \"phone_number\",\r\n                        \"path\": [\r\n                            \"phone_number\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"verification_method_information\",\r\n                        \"path\": [\r\n                            \"verification_method_information\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"phone_number\",\r\n                        \"verification_method_information\"\r\n                    ],\r\n                    [\r\n                        \"registered_family_name\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp submission valid signature",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\"student_id_credential_query\":[\"eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiIsIng1YyI6WyJNSUlCNVRDQ0FZdWdBd0lCQWdJUUdVZEYwa0JpUUdEYXdwKzBkQlNTNWpBS0JnZ3Foa2pPUFFRREFqQWRNUTR3REFZRFZRUURFd1ZCYm1sdGJ6RUxNQWtHQTFVRUJoTUNUa3d3SGhjTk1qVXdOREV5TVRReU16TXdXaGNOTWpZd05UQXlNVFF5TXpNd1dqQWhNUkl3RUFZRFZRUURFd2xqY21Wa2J5QmtZM014Q3pBSkJnTlZCQVlUQWs1TU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRUZYVk5BMGxhYSs1UDJuazVQSkZvdjh4aEJGTno1VU9KQklWc3lrMFNLU2ZxVGZLTUI2UitjRkROaWpkbUJZeXVFYVVnTWd1VWM4aE9Wbm5yZVc5dGhLT0JxRENCcFRBZEJnTlZIUTRFRmdRVVlSOHZGUVRsa2pmMS9ObktlWnh2WTBaejNhQXdEZ1lEVlIwUEFRSC9CQVFEQWdlQU1CVUdBMVVkSlFFQi93UUxNQWtHQnlpQmpGMEZBUUl3SHdZRFZSMGpCQmd3Rm9BVUw5OHdhTll2OVFueElIYjVDRmd4anZaVXRVc3dJUVlEVlIwU0JCb3dHSVlXYUhSMGNITTZMeTltZFc1clpTNWhibWx0Ynk1cFpEQVpCZ05WSFJFRUVqQVFnZzVtZFc1clpTNWhibWx0Ynk1cFpEQUtCZ2dxaGtqT1BRUURBZ05JQURCRkFpQkJ3ZFMvY0ZCczNhd3RmUDlHRlZrZ1NPSVRRZFBCTUxoc0pCeWpnN2wyTFFJaEFQUUpXeTdxUXNmcTJHcmRwY0dYSHJEVkswdy9YblBGMlhBVDZyVFg4dUNQIiwiTUlJQnp6Q0NBWFdnQXdJQkFnSVFWd0FGb2xXUWltOTRnbXlDaWMzYkNUQUtCZ2dxaGtqT1BRUURBakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d0hoY05NalF3TlRBeU1UUXlNek13V2hjTk1qZ3dOVEF5TVRReU16TXdXakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFRQy9ZeUJwY1JRWDhaWHBIZnJhMVROZFNiUzdxemdIWUhKM21zYklyOFRKTFBOWkk4VWw4ekpsRmRRVklWbHM1KzVDbENiTitKOUZVdmhQR3M0QXpBK280R1dNSUdUTUIwR0ExVWREZ1FXQkJRdjN6Qm8xaS8xQ2ZFZ2R2a0lXREdPOWxTMVN6QU9CZ05WSFE4QkFmOEVCQU1DQVFZd0lRWURWUjBTQkJvd0dJWVdhSFIwY0hNNkx5OW1kVzVyWlM1aGJtbHRieTVwWkRBU0JnTlZIUk1CQWY4RUNEQUdBUUgvQWdFQU1Dc0dBMVVkSHdRa01DSXdJS0Flb0J5R0dtaDBkSEJ6T2k4dlpuVnVhMlV1WVc1cGJXOHVhV1F2WTNKc01Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ1RnODBBbXFWSEpMYVp0MnV1aEF0UHFLSVhhZlAyZ2h0ZDlPQ21kRDUxWndJZ0t2VmtyZ1RZbHhTUkFibUtZNk1sa0g4bU0zU05jbkVKazlmR1Z3SkcrKzA9Il19.eyJjcmVkZW50aWFsX3R5cGUiOiJNU0lTRE4iLCJuYmYiOjE3NTI5ODQ3MzcsImV4cCI6MTc4NTM4NDczNywidmN0IjoiZXUuZXVyb3BhLmVjLmV1ZGkubXNpc2RuLjEiLCJjbmYiOnsia2lkIjoiZGlkOmp3azpleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TWpVMklpd2llQ0k2SWxKUk5XSkRiMngzUkZKV1pHUjRhbkk1TFUweUxVNUtPRVZ1TjFwSE1tTXpVbkZzVTJKVVR6TlJUMFVpTENKNUlqb2lZVlpFVVZkak5TMUJZbmhIYmxoV2JYRk1WMkphWmpGR1ZsWjFOVEF5TW0xaGFHdHpSVTh3VTJSZmR5SXNJblZ6WlNJNkluTnBaeUo5IzAifSwiaXNzIjoiaHR0cHM6Ly9mdW5rZS5hbmltby5pZCIsImlhdCI6MTc1Mzk0MjUyNywiX3NkIjpbIjI5SXE0b29UNzhGMkI1bFI1RzhGSGhGWWJKWmlER29vRHEySUpicFpCVG8iLCIzZVNTOEtZcUZzQVVHZVhIVWhwU21qd1k2TG5XaVJCMTVXYXRLY0ZTNzhJIiwiNE9mZGdDalZPUTJMbzhESXpTUEpodVVWT25yWGhjX1dkTGpCZDcwRGJFUSIsIkFwMWVweTdtVThiRkdrNXZkWXdlMjZma2pUY2taaW1uMDlncFlSR25XY3ciLCJEU0NWZHY3WklSOEZNNTR4c05MVlZqYndJc0JjcE9EUllHRTlCOTFra19RIiwiRnMwbGVHT0VMUU85ejhYblZsbVJTdXRUX0d3dDRTOWNubUJLcDF4TnRyQSIsIlFTbjl3dUx3LUJKY3VLRF9URHl0NGcyZlR4LU1KcmNyVzM0bVpKdHhtc0kiLCJfZDkyZVNKcW9FemdhQlctcFU2NUY2N3FOUno2Y2owRkJObDJYcTFmRWdFIiwia3VwOXhVUjZYMDZ5X3RiVVBPTzJ4VWxiWHJReG1qalRiVE9zMktYUUM4YyIsInBIYmh1eWxJbkZnaGtPY3hqcHVKb0o0S0hITUhfT2JSOWxYX0ZUa2Vmb2ciLCJ4YW1wZmJkRHJfd05LUllKN1F6NlAxZEZJcGJvMTJFdHRfZkMzYko4MDFvIl0sIl9zZF9hbGciOiJzaGEtMjU2In0.pf3MHMEAma64_-8mfmPdLCNzgzz5K0_EianTPd5IUzMlkXhB1v4NtQmRiARlLvTd9kkUChhW4lascAkW8TOnSA~WyI4NzY3MzA2NTE3OTE1MTMzMTI2NDI5MTUiLCJwaG9uZV9udW1iZXIiLCI0OTE1MTEyMzQ1NjciXQ~WyIyNzgzODk0ODU5Mjc2ODY0NTY1NjkxNzUiLCJyZWdpc3RlcmVkX2ZhbWlseV9uYW1lIiwiTXVzdGVybWFuIl0~WyI5Njk4OTYzODY5MDAwMTE3MzM0MTE0NDQiLCJyZWdpc3RlcmVkX2dpdmVuX25hbWUiLCJKb2huIE1pY2hhZWwiXQ~WyIxMDE3NzAzNzY5OTU2Mzc0MjI4NTIwMDQ4IiwiY29udHJhY3Rfb3duZXIiLHRydWVd~WyIxMTcwMTg2ODQ0MTkyNTczMzQyOTYyNDg5IiwiZW5kX3VzZXIiLGZhbHNlXQ~WyI0MzI1MjkxNDE2MzczOTU0MzgxNDM5NTUiLCJtb2JpbGVfb3BlcmF0b3IiLCJUZWxla29tX0RFIl0~WyI2ODA1NjkyNDQ3MTA1NjQ3ODc1ODQxNzUiLCJpc3N1aW5nX29yZ2FuaXphdGlvbiIsIlRlbE9yZyJd~WyI5MzE5ODU3NzkxNTk0Njc0ODE2NTg4ODciLCJ2ZXJpZmljYXRpb25fZGF0ZSIsIjIwMjMtMDgtMjUiXQ~WyI2MTkxMTk5NjI3Mzg2MDQ5MjI4ODkwMjEiLCJ2ZXJpZmljYXRpb25fbWV0aG9kX2luZm9ybWF0aW9uIiwiTnVtYmVyVmVyaWZ5Il0~WyIzNzM2NzUzNDQwNDA1ODI4Mzc2MTE0MjQiLCJpc3N1YW5jZV9kYXRlIiwiMjAyNS0wNy0yMFQwNDoxMjoxNy4wODlaIl0~WyI1NjU0NDMyNzk2MjEwMjQ2ODk0NjQ3MDgiLCJleHBpcnlfZGF0ZSIsIjIwMjYtMDctMzBUMDQ6MTI6MTcuMDg5WiJd~\"]}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{1_8_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{1_8_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-result",
+                    "{{1_8_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results v2",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{1_8_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-results",
+                    "{{1_8_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "1.9. sd-jwt - expired - dcql request",
+          "item": [
+            {
+              "name": "vp request using dcql",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "pm.collectionVariables.set('1_9_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('1_9_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net\",\r\n    \"nonce\": \"yMRlSK2ZT31GdWbedhk4hA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"dc+sd-jwt\",\r\n                \"require_cryptographic_holder_binding\": false,\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"TestCredential_SD_JWT\"\r\n                    ]\r\n                }\r\n            }\r\n        ]    \r\n    }        \r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp submission expired",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\"student_id_credential_query\":[\"eyJhbGciOiJFUzI1NiIsInR5cCI6InZjK3NkLWp3dCIsIng1YyI6WyJNSUlCSkRDQnlxQURBZ0VDQWhSNE5xOStNUjVyTFZFS242U1FSd0daRHh3SWpUQUtCZ2dxaGtqT1BRUURBakFTTVJBd0RnWURWUVFEREFkRlExOVVaWE4wTUI0WERUSTFNRGt3TXpFd01qVXhPVm9YRFRJMU1Ea3dNekV3TWpreE9Wb3dFakVRTUE0R0ExVUVBd3dIUlVOZlZHVnpkREJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUFCTXJvelh2R2tuZm5SRnFDMG8vcWRwK3Zpd1lvT2drVmRRZkpuWFZMMlJjYUFHL0dOSEVYMkxPVWxJY3JtVDZNS1o4WkhFWXdWMU9tUTB5OUNOd0ViRlF3Q2dZSUtvWkl6ajBFQXdJRFNRQXdSZ0loQU9VSjkvTXdJUGVvYnJMRERhT2pLQkVuSDJoTjVTekY4dnRmOTBVZTY5NHJBaUVBeFFXeGo5dUt1MlliK2pDYk03a0lxaFcrNkNVYWk5WGNLWG9MdFNwanJEYz0iXX0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTY5MDAwMDAwMCwiaWQiOiIxMjM0IiwidmN0IjoiVGVzdENyZWRlbnRpYWxfU0RfSldUIiwiX3NkIjpbImJEVFJ2bTUtWW4tSEc3Y3FwVlI1T1ZSSVhzU2FCazU3SmdpT3FfajFWSTQiLCJldDNVZlJ5bHdWcmZYZFBLemc3OWhjakQxSXR6b1E5b0JvWFJHdE1vc0ZrIiwieldmWk5TMTlBdGJSU1RibzdzSlJuMEJaUXZXUmRjaG9DN1VaYWJGcmpZOCJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vaXNzdWVyLmV4YW1wbGUuY29tIiwibmJmIjoxNjkwMDAzNjAwLCJleHAiOjE2OTAwODAwMDB9.P5tm14I5pja6G0spZQ07HbYBZwGZCeNH86VqyfRrWYgZrx5fv75ndJdiCEV-Mvj84p8ZWLFgeY5uPoS_ypT17A~\"]}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{1_9_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{1_9_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-result",
+                    "{{1_9_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results v2",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{1_9_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-results",
+                    "{{1_9_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "2.1. multiple vp submission - ldp_vp, sd_jwt - require_cryptographic_holder_binding false",
+          "item": [
+            {
+              "name": "vp request using dcql",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "pm.collectionVariables.set('2_1_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('2_1_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net\",\r\n    \"nonce\": \"yMRlSK2ZT31GdWbedhk4hA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"vc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"eu.europa.ec.eudi.msisdn.1\"\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false,\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"phone_number\",\r\n                        \"path\": [\r\n                            \"phone_number\"\r\n                        ]\r\n                    }\r\n                ]\r\n            },\r\n            {\r\n                \"id\": \"id_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"student_id_credential_query\",\r\n                        \"id_credential_query\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "1 ldp_vc valid, 1 sd_jwt valid",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\"id_credential_query\":[{\"issuanceDate\":\"2025-12-23T10:27:09.133Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"value\":\"MLE\",\"language\":\"eng\"}],\"city\":[{\"value\":\"TEST_CITYeng\",\"language\":\"eng\"}],\"phone\":\"2261640506\",\"fullName\":[{\"value\":\"TEST_FULLNAMEeng\",\"language\":\"eng\"}],\"addressLine1\":[{\"value\":\"TEST_ADDRESSLINE1eng\",\"language\":\"eng\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\"UIN\":\"2042351307\",\"email\":\"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"},\"proof\":{\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"https://api.released.mosip.net/.well-known/ida-public-key.json\",\"type\":\"RsaSignature2018\",\"created\":\"2025-12-23T10:27:09Z\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"},\"id\":\"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\"type\":[\"MOSIPVerifiableCredential\",\"VerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",{\"sec\":\"https://w3id.org/security#\"}],\"issuer\":\"https://api.released.mosip.net/.well-known/ida-controller.json\"}],\"student_id_credential_query\":[\"eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiIsIng1YyI6WyJNSUlCNVRDQ0FZdWdBd0lCQWdJUUdVZEYwa0JpUUdEYXdwKzBkQlNTNWpBS0JnZ3Foa2pPUFFRREFqQWRNUTR3REFZRFZRUURFd1ZCYm1sdGJ6RUxNQWtHQTFVRUJoTUNUa3d3SGhjTk1qVXdOREV5TVRReU16TXdXaGNOTWpZd05UQXlNVFF5TXpNd1dqQWhNUkl3RUFZRFZRUURFd2xqY21Wa2J5QmtZM014Q3pBSkJnTlZCQVlUQWs1TU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRUZYVk5BMGxhYSs1UDJuazVQSkZvdjh4aEJGTno1VU9KQklWc3lrMFNLU2ZxVGZLTUI2UitjRkROaWpkbUJZeXVFYVVnTWd1VWM4aE9Wbm5yZVc5dGhLT0JxRENCcFRBZEJnTlZIUTRFRmdRVVlSOHZGUVRsa2pmMS9ObktlWnh2WTBaejNhQXdEZ1lEVlIwUEFRSC9CQVFEQWdlQU1CVUdBMVVkSlFFQi93UUxNQWtHQnlpQmpGMEZBUUl3SHdZRFZSMGpCQmd3Rm9BVUw5OHdhTll2OVFueElIYjVDRmd4anZaVXRVc3dJUVlEVlIwU0JCb3dHSVlXYUhSMGNITTZMeTltZFc1clpTNWhibWx0Ynk1cFpEQVpCZ05WSFJFRUVqQVFnZzVtZFc1clpTNWhibWx0Ynk1cFpEQUtCZ2dxaGtqT1BRUURBZ05JQURCRkFpQkJ3ZFMvY0ZCczNhd3RmUDlHRlZrZ1NPSVRRZFBCTUxoc0pCeWpnN2wyTFFJaEFQUUpXeTdxUXNmcTJHcmRwY0dYSHJEVkswdy9YblBGMlhBVDZyVFg4dUNQIiwiTUlJQnp6Q0NBWFdnQXdJQkFnSVFWd0FGb2xXUWltOTRnbXlDaWMzYkNUQUtCZ2dxaGtqT1BRUURBakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d0hoY05NalF3TlRBeU1UUXlNek13V2hjTk1qZ3dOVEF5TVRReU16TXdXakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFRQy9ZeUJwY1JRWDhaWHBIZnJhMVROZFNiUzdxemdIWUhKM21zYklyOFRKTFBOWkk4VWw4ekpsRmRRVklWbHM1KzVDbENiTitKOUZVdmhQR3M0QXpBK280R1dNSUdUTUIwR0ExVWREZ1FXQkJRdjN6Qm8xaS8xQ2ZFZ2R2a0lXREdPOWxTMVN6QU9CZ05WSFE4QkFmOEVCQU1DQVFZd0lRWURWUjBTQkJvd0dJWVdhSFIwY0hNNkx5OW1kVzVyWlM1aGJtbHRieTVwWkRBU0JnTlZIUk1CQWY4RUNEQUdBUUgvQWdFQU1Dc0dBMVVkSHdRa01DSXdJS0Flb0J5R0dtaDBkSEJ6T2k4dlpuVnVhMlV1WVc1cGJXOHVhV1F2WTNKc01Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ1RnODBBbXFWSEpMYVp0MnV1aEF0UHFLSVhhZlAyZ2h0ZDlPQ21kRDUxWndJZ0t2VmtyZ1RZbHhTUkFibUtZNk1sa0g4bU0zU05jbkVKazlmR1Z3SkcrKzA9Il19.eyJjcmVkZW50aWFsX3R5cGUiOiJNU0lTRE4iLCJuYmYiOjE3NTI5ODQ3MzcsImV4cCI6MTc4NTM4NDczNywidmN0IjoiZXUuZXVyb3BhLmVjLmV1ZGkubXNpc2RuLjEiLCJjbmYiOnsia2lkIjoiZGlkOmp3azpleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TWpVMklpd2llQ0k2SWxKUk5XSkRiMngzUkZKV1pHUjRhbkk1TFUweUxVNUtPRVZ1TjFwSE1tTXpVbkZzVTJKVVR6TlJUMFVpTENKNUlqb2lZVlpFVVZkak5TMUJZbmhIYmxoV2JYRk1WMkphWmpGR1ZsWjFOVEF5TW0xaGFHdHpSVTh3VTJSZmR5SXNJblZ6WlNJNkluTnBaeUo5IzAifSwiaXNzIjoiaHR0cHM6Ly9mdW5rZS5hbmltby5pZCIsImlhdCI6MTc1Mzk0MjUyNywiX3NkIjpbIjI5SXE0b29UNzhGMkI1bFI1RzhGSGhGWWJKWmlER29vRHEySUpicFpCVG8iLCIzZVNTOEtZcUZzQVVHZVhIVWhwU21qd1k2TG5XaVJCMTVXYXRLY0ZTNzhJIiwiNE9mZGdDalZPUTJMbzhESXpTUEpodVVWT25yWGhjX1dkTGpCZDcwRGJFUSIsIkFwMWVweTdtVThiRkdrNXZkWXdlMjZma2pUY2taaW1uMDlncFlSR25XY3ciLCJEU0NWZHY3WklSOEZNNTR4c05MVlZqYndJc0JjcE9EUllHRTlCOTFra19RIiwiRnMwbGVHT0VMUU85ejhYblZsbVJTdXRUX0d3dDRTOWNubUJLcDF4TnRyQSIsIlFTbjl3dUx3LUJKY3VLRF9URHl0NGcyZlR4LU1KcmNyVzM0bVpKdHhtc0kiLCJfZDkyZVNKcW9FemdhQlctcFU2NUY2N3FOUno2Y2owRkJObDJYcTFmRWdFIiwia3VwOXhVUjZYMDZ5X3RiVVBPTzJ4VWxiWHJReG1qalRiVE9zMktYUUM4YyIsInBIYmh1eWxJbkZnaGtPY3hqcHVKb0o0S0hITUhfT2JSOWxYX0ZUa2Vmb2ciLCJ4YW1wZmJkRHJfd05LUllKN1F6NlAxZEZJcGJvMTJFdHRfZkMzYko4MDFvIl0sIl9zZF9hbGciOiJzaGEtMjU2In0.pf3MHMEAma64_-8mfmPdLCNzgzz5K0_EianTPd5IUzMlkXhB1v4NtQmRiARlLvTd9kkUChhW4lascAkW8TOnSA~WyI4NzY3MzA2NTE3OTE1MTMzMTI2NDI5MTUiLCJwaG9uZV9udW1iZXIiLCI0OTE1MTEyMzQ1NjciXQ~WyIyNzgzODk0ODU5Mjc2ODY0NTY1NjkxNzUiLCJyZWdpc3RlcmVkX2ZhbWlseV9uYW1lIiwiTXVzdGVybWFuIl0~WyI5Njk4OTYzODY5MDAwMTE3MzM0MTE0NDQiLCJyZWdpc3RlcmVkX2dpdmVuX25hbWUiLCJKb2huIE1pY2hhZWwiXQ~WyIxMDE3NzAzNzY5OTU2Mzc0MjI4NTIwMDQ4IiwiY29udHJhY3Rfb3duZXIiLHRydWVd~WyIxMTcwMTg2ODQ0MTkyNTczMzQyOTYyNDg5IiwiZW5kX3VzZXIiLGZhbHNlXQ~WyI0MzI1MjkxNDE2MzczOTU0MzgxNDM5NTUiLCJtb2JpbGVfb3BlcmF0b3IiLCJUZWxla29tX0RFIl0~WyI2ODA1NjkyNDQ3MTA1NjQ3ODc1ODQxNzUiLCJpc3N1aW5nX29yZ2FuaXphdGlvbiIsIlRlbE9yZyJd~WyI5MzE5ODU3NzkxNTk0Njc0ODE2NTg4ODciLCJ2ZXJpZmljYXRpb25fZGF0ZSIsIjIwMjMtMDgtMjUiXQ~WyI2MTkxMTk5NjI3Mzg2MDQ5MjI4ODkwMjEiLCJ2ZXJpZmljYXRpb25fbWV0aG9kX2luZm9ybWF0aW9uIiwiTnVtYmVyVmVyaWZ5Il0~WyIzNzM2NzUzNDQwNDA1ODI4Mzc2MTE0MjQiLCJpc3N1YW5jZV9kYXRlIiwiMjAyNS0wNy0yMFQwNDoxMjoxNy4wODlaIl0~WyI1NjU0NDMyNzk2MjEwMjQ2ODk0NjQ3MDgiLCJleHBpcnlfZGF0ZSIsIjIwMjYtMDctMzBUMDQ6MTI6MTcuMDg5WiJd~\"]}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{2_1_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{2_1_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-result",
+                    "{{2_1_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results v2",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{2_1_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-results",
+                    "{{2_1_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "2.2. multiple vp submission - valid, expired, invalid - require_cryptographic_holder_binding false",
+          "item": [
+            {
+              "name": "vp request using dcql",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "pm.collectionVariables.set('2_2_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('2_2_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net\",\r\n    \"nonce\": \"yMRlSK2ZT31GdWbedhk4hA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential\",\r\n                \"format\": \"dc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"TestCredential_SD_JWT\"\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false\r\n            },\r\n            {\r\n                \"id\": \"id_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ],\r\n                        [\r\n                            \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                            \"https://example.org/credentials#MockVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                },\r\n                \"multiple\": true,\r\n                \"require_cryptographic_holder_binding\": false\r\n            }\r\n        ],\r\n        \"credential_sets\": [\r\n            {\r\n                \"options\": [\r\n                    [\r\n                        \"id_credential_query\",\r\n                        \"student_id_credential\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "1 valid, 1 expired and 1 invalid vc",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\"id_credential_query\":[{\"issuanceDate\":\"2025-12-23T10:27:09.133Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"value\":\"MLE\",\"language\":\"eng\"}],\"city\":[{\"value\":\"TEST_CITYeng\",\"language\":\"eng\"}],\"phone\":\"2261640506\",\"fullName\":[{\"value\":\"TEST_FULLNAMEeng\",\"language\":\"eng\"}],\"addressLine1\":[{\"value\":\"TEST_ADDRESSLINE1eng\",\"language\":\"eng\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\"UIN\":\"2042351307\",\"email\":\"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"},\"proof\":{\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"https://api.released.mosip.net/.well-known/ida-public-key.json\",\"type\":\"RsaSignature2018\",\"created\":\"2025-12-23T10:27:09Z\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"},\"id\":\"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\"type\":[\"MOSIPVerifiableCredential\",\"VerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",{\"sec\":\"https://w3id.org/security#\"}],\"issuer\":\"https://api.released.mosip.net/.well-known/ida-controller.json\"},{\"credentialSubject\":{\"VID\":9876543210,\"gender\":[{\"language\":\"eng\",\"value\":\"Male\"},{\"language\":\"fra\",\"value\":\"Mâle\"},{\"language\":\"ara\",\"value\":\"ذكر\"}],\"province\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"phone\":\"+919427357934\",\"postalCode\":45009,\"fullName\":[{\"language\":\"fra\",\"value\":\"Siddharth K Mansour\"},{\"language\":\"ara\",\"value\":\"تتگلدكنسَزقهِقِفل دسييسيكدكنوڤو\"},{\"language\":\"eng\",\"value\":\"Siddharth K Mansour\"}],\"dateOfBirth\":\"1987/11/25\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkZ2WU5MSWR3b1VESUp6cG9IelNadXNHV215VkV2Vnk5UmZ3TWY0VU9OODQiLCJhbGciOiJSUzI1NiIsIm4iOiJ3akJCcmNKTThjRHAwTTVQVy1yWmRMNExQdk95TzZvQ292YmR0SlBKTzEwNHVEV0Rib2JFbU5nYkwxOHN1cDlFZFJYLTdIVWxQR1hGSGJINXhZamhJWFl3bDF2NUJCRDVqSjBseUxWQnB5YjczSFE3SHRVaEhaTWxuNUtMNXluUW9wLVctVDNvYWxBRVFRTmJxTHhuUGJRVEZORjItSEpRYUxlOXg2bDdWeVdidG9SSjhCaV9mLTBXaW9WWF9NUk9OQWpjNTlLMzgwZ2VWYmg0YjExaWdzVTk2TnR2OENBTzVpcHBZcXhZdDE0UUd2WHVaczBwcTdiV05GbWFGZGd5X3dPa3E1UXdYbVdkWGo3NWpLNWprNXRiV1NReV9icEZPUnR1MWFmZmNaWXF5enpSOXZrbGZieU9NM0gtQVZmU3JpR3lmOVdkMU95elVVQTJkdkFLc1EifQ==\",\"UIN\":9876543210,\"region\":[{\"language\":\"eng\",\"value\":\"yuanwee\"}],\"email\":\"siddhartha.km@gmail.com\"},\"validUntil\":\"2028-01-08T07:19:56.385Z\",\"validFrom\":\"2026-01-08T07:19:56.385Z\",\"id\":\"https://mosip.io/credential/ec7abcf7-2dbd-4124-b860-971621452d2b\",\"type\":[\"VerifiableCredential\",\"MockVerifiableCredential\"],\"@context\":[\"https://www.w3.org/ns/credentials/v2\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"issuer\":\"did:web:inji.github.io:inji-config:dev-int-inji:mock-identity\",\"credentialStatus\":{\"statusPurpose\":\"revocation\",\"statusListIndex\":\"94010\",\"id\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a#94010\",\"type\":\"BitstringStatusListEntry\",\"statusListCredential\":\"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/credentials/status-list/25b62812-7d5d-4660-b233-5e2d1263c83a\"},\"proof\":{\"verificationMethod\":\"did:web:mosip.github.io:inji-config:qa-inji1:landregistry#UHNnpAY2hEkSnXqkc3aS07EgTEaw9WC64kpO3jvP9X0\",\"created\":\"2025-11-24T07:37:30Z\",\"type\":\"Ed25519Signature2020\",\"proofPurpose\":\"assertionMethod\",\"proofValue\":\"z5gfKobfm77qMGgs41LDkoSjZdS7fTx19runRBxPSckQUfCxMgbmnF9SiGwgJrkuzx1yYqdvkfW7u69v5cMc3ePCp\"}}],\"student_id_credential\":[\"eyJhbGciOiJFUzI1NiIsInR5cCI6InZjK3NkLWp3dCIsIng1YyI6WyJNSUlCSkRDQnlxQURBZ0VDQWhSNE5xOStNUjVyTFZFS242U1FSd0daRHh3SWpUQUtCZ2dxaGtqT1BRUURBakFTTVJBd0RnWURWUVFEREFkRlExOVVaWE4wTUI0WERUSTFNRGt3TXpFd01qVXhPVm9YRFRJMU1Ea3dNekV3TWpreE9Wb3dFakVRTUE0R0ExVUVBd3dIUlVOZlZHVnpkREJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUFCTXJvelh2R2tuZm5SRnFDMG8vcWRwK3Zpd1lvT2drVmRRZkpuWFZMMlJjYUFHL0dOSEVYMkxPVWxJY3JtVDZNS1o4WkhFWXdWMU9tUTB5OUNOd0ViRlF3Q2dZSUtvWkl6ajBFQXdJRFNRQXdSZ0loQU9VSjkvTXdJUGVvYnJMRERhT2pLQkVuSDJoTjVTekY4dnRmOTBVZTY5NHJBaUVBeFFXeGo5dUt1MlliK2pDYk03a0lxaFcrNkNVYWk5WGNLWG9MdFNwanJEYz0iXX0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTY5MDAwMDAwMCwiaWQiOiIxMjM0IiwidmN0IjoiVGVzdENyZWRlbnRpYWxfU0RfSldUIiwiX3NkIjpbImJEVFJ2bTUtWW4tSEc3Y3FwVlI1T1ZSSVhzU2FCazU3SmdpT3FfajFWSTQiLCJldDNVZlJ5bHdWcmZYZFBLemc3OWhjakQxSXR6b1E5b0JvWFJHdE1vc0ZrIiwieldmWk5TMTlBdGJSU1RibzdzSlJuMEJaUXZXUmRjaG9DN1VaYWJGcmpZOCJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vaXNzdWVyLmV4YW1wbGUuY29tIiwibmJmIjoxNjkwMDAzNjAwLCJleHAiOjE2OTAwODAwMDB9.P5tm14I5pja6G0spZQ07HbYBZwGZCeNH86VqyfRrWYgZrx5fv75ndJdiCEV-Mvj84p8ZWLFgeY5uPoS_ypT17A~\"]}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{2_2_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{2_2_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-result",
+                    "{{2_2_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results v2",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{2_2_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-results",
+                    "{{2_2_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "3.1. vp-request with response_code",
+          "item": [
+            {
+              "name": "vp request using dcql",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "",
+                      "var txnId = responseJson.transactionId;",
+                      "var encodedTxnId = btoa(txnId);",
+                      "const transaction_id = \"transaction_id=\"+ encodedTxnId;",
+                      "pm.collectionVariables.set('3_1_txnId', transaction_id);",
+                      "pm.collectionVariables.set('3_1_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"decentralized_identifier:did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\r\n    \"responseCodeValidationRequired\": true,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"life_insurance_credential_id\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                        \"https://inji.github.io/inji-config/contexts/insurance-context.json#InsuranceCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp submission valid signature",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "var redirectUri = responseJson.redirect_uri;",
+                      "",
+                      "if (redirectUri) {",
+                      "    const url = new URL(redirectUri);",
+                      "    const params = new URLSearchParams(url.hash.substring(1));",
+                      "    const responseCode = params.get(\"response_code\");",
+                      "    const transactionId = params.get(\"transaction_id\");",
+                      "",
+                      "    pm.collectionVariables.set(\"3_1_responseCode\", responseCode);",
+                      "    pm.collectionVariables.set(\"3_1_transactionId\", transactionId);",
+                      "",
+                      "    console.log(\"Captured Response Code: \" + responseCode);",
+                      "    console.log(\"Captured Transaction ID (Base64): \" + transactionId);",
+                      "} else {",
+                      "    pm.collectionVariables.set(\"3_1_responseCode\", null);",
+                      "    pm.collectionVariables.set(\"3_1_transactionId\", null);",
+                      "}",
+                      "",
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\n  \"life_insurance_credential_id\": [\n    {\n      \"@context\": [\n        \"https://www.w3.org/2018/credentials/v1\",\n        \"https://w3id.org/security/suites/jws-2020/v1\"\n      ],\n      \"id\": \"urn:uuid:040c6666-f766-445d-b798-bdd94fd48f43\",\n      \"proof\": {\n        \"verificationMethod\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ#0\",\n        \"challenge\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n        \"domain\": \"decentralized_identifier:did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\n        \"type\": \"JsonWebSignature2020\",\n        \"jws\": \"eyJjcml0IjpbImI2NCJdLCJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2V9..dgsVZai4skG2hslojGGjibLSzB7Yt6FoSNpS_2xXeXdZM_GD0OKXHSVdoE-CZd4szffjwEGOZo5wRkV_3vTHCA\"\n      },\n      \"type\": [\n        \"VerifiablePresentation\"\n      ],\n      \"verifiableCredential\": [\n        {\n          \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://inji.github.io/inji-config/contexts/insurance-context.json\",\n            \"https://w3id.org/security/suites/ed25519-2020/v1\"\n          ],\n          \"issuanceDate\": \"2026-06-15T07:06:32.635Z\",\n          \"issuer\": \"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f\",\n          \"credentialSubject\": {\n            \"mobile\": \"67845634567\",\n            \"policyExpiresOn\": \"2024-06-17\",\n            \"email\": \"Afterbirth@gmail.com\",\n            \"id\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ==\",\n            \"gender\": \"Male\",\n            \"benefits\": [\n              \"No Toll Fee\",\n              \"Free Movie Tickets\"\n            ],\n            \"policyNumber\": \"8080\",\n            \"fullName\": \"Afterbirth\",\n            \"policyIssuedOn\": \"2027-05-20\",\n            \"dob\": \"2025-02-04\",\n            \"policyName\": \"Afterbirth\"\n          },\n          \"id\": \"did:rcw:954e7dbb-7f2e-4b38-ac55-4551a67a2abb\",\n          \"expirationDate\": \"2031-06-15T07:06:32.620Z\",\n          \"type\": [\n            \"VerifiableCredential\",\n            \"InsuranceCredential\"\n          ],\n          \"proof\": {\n            \"proofValue\": \"z9mh7b8E2YXYe1fyPfEksRgviebnDBgS8g43RqQggWiLbST4imHPdgbFdVELmwHk6vrfjFPuo8Jadzz6SwUoMiwa\",\n            \"type\": \"Ed25519Signature2020\",\n            \"created\": \"2026-06-15T07:06:33Z\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"verificationMethod\": \"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f#key-0\"\n          }\n        }\n      ],\n      \"holder\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ#0\"\n    }\n  ]\n}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{3_1_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp session results with response_code",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Cookie",
+                    "value": "{{3_1_txnId}}",
+                    "type": "text"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true,\n  \"responseCode\": \"{{3_1_responseCode}}\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-session-results",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-session-results"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "3.2. vp-session-request with response_code",
+          "item": [
+            {
+              "name": "vp session request using dcql",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "",
+                      "const encoded = btoa(responseJson.transactionId);",
+                      "const transactionId = \"transaction_id=\"+ encoded;",
+                      "pm.collectionVariables.set('3_2_txnId', transactionId);",
+                      "pm.collectionVariables.set('3_2_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"decentralized_identifier:did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\r\n    \"responseCodeValidationRequired\": true,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"life_insurance_credential_id\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                        \"https://inji.github.io/inji-config/contexts/insurance-context.json#InsuranceCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-session-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-session-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp submission valid signature",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "var redirectUri = responseJson.redirect_uri;",
+                      "",
+                      "if (redirectUri) {",
+                      "    const url = new URL(redirectUri);",
+                      "    const params = new URLSearchParams(url.hash.substring(1));",
+                      "    const responseCode = params.get(\"response_code\");",
+                      "    const transactionId = params.get(\"transaction_id\");",
+                      "",
+                      "    pm.collectionVariables.set(\"3_2_responseCode\", responseCode);",
+                      "    pm.collectionVariables.set(\"3_2_transactionId\", transactionId);",
+                      "",
+                      "    console.log(\"Captured Response Code: \" + responseCode);",
+                      "    console.log(\"Captured Transaction ID (Base64): \" + transactionId);",
+                      "} else {",
+                      "    pm.collectionVariables.set(\"3_2_responseCode\", null);",
+                      "    pm.collectionVariables.set(\"3_2_transactionId\", null);",
+                      "}",
+                      "",
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\n  \"life_insurance_credential_id\": [\n    {\n      \"@context\": [\n        \"https://www.w3.org/2018/credentials/v1\",\n        \"https://w3id.org/security/suites/jws-2020/v1\"\n      ],\n      \"id\": \"urn:uuid:040c6666-f766-445d-b798-bdd94fd48f43\",\n      \"proof\": {\n        \"verificationMethod\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ#0\",\n        \"challenge\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n        \"domain\": \"decentralized_identifier:did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\n        \"type\": \"JsonWebSignature2020\",\n        \"jws\": \"eyJjcml0IjpbImI2NCJdLCJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2V9..dgsVZai4skG2hslojGGjibLSzB7Yt6FoSNpS_2xXeXdZM_GD0OKXHSVdoE-CZd4szffjwEGOZo5wRkV_3vTHCA\"\n      },\n      \"type\": [\n        \"VerifiablePresentation\"\n      ],\n      \"verifiableCredential\": [\n        {\n          \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://inji.github.io/inji-config/contexts/insurance-context.json\",\n            \"https://w3id.org/security/suites/ed25519-2020/v1\"\n          ],\n          \"issuanceDate\": \"2026-06-15T07:06:32.635Z\",\n          \"issuer\": \"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f\",\n          \"credentialSubject\": {\n            \"mobile\": \"67845634567\",\n            \"policyExpiresOn\": \"2024-06-17\",\n            \"email\": \"Afterbirth@gmail.com\",\n            \"id\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ==\",\n            \"gender\": \"Male\",\n            \"benefits\": [\n              \"No Toll Fee\",\n              \"Free Movie Tickets\"\n            ],\n            \"policyNumber\": \"8080\",\n            \"fullName\": \"Afterbirth\",\n            \"policyIssuedOn\": \"2027-05-20\",\n            \"dob\": \"2025-02-04\",\n            \"policyName\": \"Afterbirth\"\n          },\n          \"id\": \"did:rcw:954e7dbb-7f2e-4b38-ac55-4551a67a2abb\",\n          \"expirationDate\": \"2031-06-15T07:06:32.620Z\",\n          \"type\": [\n            \"VerifiableCredential\",\n            \"InsuranceCredential\"\n          ],\n          \"proof\": {\n            \"proofValue\": \"z9mh7b8E2YXYe1fyPfEksRgviebnDBgS8g43RqQggWiLbST4imHPdgbFdVELmwHk6vrfjFPuo8Jadzz6SwUoMiwa\",\n            \"type\": \"Ed25519Signature2020\",\n            \"created\": \"2026-06-15T07:06:33Z\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"verificationMethod\": \"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f#key-0\"\n          }\n        }\n      ],\n      \"holder\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ#0\"\n    }\n  ]\n}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{3_2_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp session results with response_code",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Cookie",
+                    "value": "{{3_2_txnId}}",
+                    "type": "text"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true,\n  \"responseCode\": \"{{3_2_responseCode}}\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-session-results",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-session-results"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "3.3. vp-session-request without response_code",
+          "item": [
+            {
+              "name": "vp session request using dcql",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "",
+                      "const encoded = btoa(responseJson.transactionId);",
+                      "const transactionId = \"transaction_id=\"+ encoded;",
+                      "pm.collectionVariables.set('3_3_txnId', transactionId);",
+                      "pm.collectionVariables.set('3_3_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"decentralized_identifier:did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"life_insurance_credential_id\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                        \"https://inji.github.io/inji-config/contexts/insurance-context.json#InsuranceCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-session-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-session-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp submission valid signature",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\n  \"life_insurance_credential_id\": [\n    {\n      \"@context\": [\n        \"https://www.w3.org/2018/credentials/v1\",\n        \"https://w3id.org/security/suites/jws-2020/v1\"\n      ],\n      \"id\": \"urn:uuid:040c6666-f766-445d-b798-bdd94fd48f43\",\n      \"proof\": {\n        \"verificationMethod\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ#0\",\n        \"challenge\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n        \"domain\": \"decentralized_identifier:did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\n        \"type\": \"JsonWebSignature2020\",\n        \"jws\": \"eyJjcml0IjpbImI2NCJdLCJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2V9..dgsVZai4skG2hslojGGjibLSzB7Yt6FoSNpS_2xXeXdZM_GD0OKXHSVdoE-CZd4szffjwEGOZo5wRkV_3vTHCA\"\n      },\n      \"type\": [\n        \"VerifiablePresentation\"\n      ],\n      \"verifiableCredential\": [\n        {\n          \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://inji.github.io/inji-config/contexts/insurance-context.json\",\n            \"https://w3id.org/security/suites/ed25519-2020/v1\"\n          ],\n          \"issuanceDate\": \"2026-06-15T07:06:32.635Z\",\n          \"issuer\": \"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f\",\n          \"credentialSubject\": {\n            \"mobile\": \"67845634567\",\n            \"policyExpiresOn\": \"2024-06-17\",\n            \"email\": \"Afterbirth@gmail.com\",\n            \"id\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ==\",\n            \"gender\": \"Male\",\n            \"benefits\": [\n              \"No Toll Fee\",\n              \"Free Movie Tickets\"\n            ],\n            \"policyNumber\": \"8080\",\n            \"fullName\": \"Afterbirth\",\n            \"policyIssuedOn\": \"2027-05-20\",\n            \"dob\": \"2025-02-04\",\n            \"policyName\": \"Afterbirth\"\n          },\n          \"id\": \"did:rcw:954e7dbb-7f2e-4b38-ac55-4551a67a2abb\",\n          \"expirationDate\": \"2031-06-15T07:06:32.620Z\",\n          \"type\": [\n            \"VerifiableCredential\",\n            \"InsuranceCredential\"\n          ],\n          \"proof\": {\n            \"proofValue\": \"z9mh7b8E2YXYe1fyPfEksRgviebnDBgS8g43RqQggWiLbST4imHPdgbFdVELmwHk6vrfjFPuo8Jadzz6SwUoMiwa\",\n            \"type\": \"Ed25519Signature2020\",\n            \"created\": \"2026-06-15T07:06:33Z\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"verificationMethod\": \"did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f#key-0\"\n          }\n        }\n      ],\n      \"holder\": \"did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5IiwieCI6Im9JUG1BUjZIb0ZqcWRLVFltWE5rVmxTeW9MNlpiMVM1bzBCei1DTXhvUVkifQ#0\"\n    }\n  ]\n}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{3_3_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp request status",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-request/{{3_3_reqId}}/status",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-request",
+                    "{{3_3_reqId}}",
+                    "status"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp session results without response_code",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Cookie",
+                    "value": "{{3_3_txnId}}",
+                    "type": "text"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-session-results",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-session-results"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "4.1. invalid holder binding",
+          "item": [
+            {
+              "name": "vp session request using dcql",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "pm.collectionVariables.set('4_1_txnId', responseJson.transactionId);",
+                      "pm.collectionVariables.set('4_1_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\r\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"id_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                        \"https://www.w3.org/2018/credentials#VerifiableCredential\",\r\n                        \"https://example.org/credentials#MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-session-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-session-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp submission invalid holder binding",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\"id_credential_query\":[{\n  \"@context\": [\n    \"https://www.w3.org/2018/credentials/v1\",\n    \"https://w3id.org/security/suites/jws-2020/v1\"\n  ],\n  \"type\": [\n    \"VerifiablePresentation\"\n  ],\n  \"verifiableCredential\": [\n    {\n      \"issuanceDate\": \"2025-12-23T10:27:09.133Z\",\n      \"credentialSubject\": {\n        \"face\": \"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\n        \"gender\": [\n          {\n            \"value\": \"MLE\",\n            \"language\": \"eng\"\n          }\n        ],\n        \"city\": [\n          {\n            \"value\": \"TEST_CITYeng\",\n            \"language\": \"eng\"\n          }\n        ],\n        \"phone\": \"2261640506\",\n        \"fullName\": [\n          {\n            \"value\": \"TEST_FULLNAMEeng\",\n            \"language\": \"eng\"\n          }\n        ],\n        \"addressLine1\": [\n          {\n            \"value\": \"TEST_ADDRESSLINE1eng\",\n            \"language\": \"eng\"\n          }\n        ],\n        \"dateOfBirth\": \"1992/04/15\",\n        \"id\": \"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\n        \"UIN\": \"2042351307\",\n        \"email\": \"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"\n      },\n      \"proof\": {\n        \"proofPurpose\": \"assertionMethod\",\n        \"verificationMethod\": \"https://api.released.mosip.net/.well-known/ida-public-key.json\",\n        \"type\": \"RsaSignature2018\",\n        \"created\": \"2025-12-23T10:27:09Z\",\n        \"jws\": \"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"\n      },\n      \"id\": \"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\n      \"type\": [\n        \"MOSIPVerifiableCredential\",\n        \"VerifiableCredential\"\n      ],\n      \"@context\": [\n        \"https://www.w3.org/2018/credentials/v1\",\n        \"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",\n        {\n          \"sec\": \"https://w3id.org/security#\"\n        }\n      ],\n      \"issuer\": \"https://api.released.mosip.net/.well-known/ida-controller.json\"\n    }\n  ],\n  \"id\": \"urn:uuid:b978c646-8c07-4c1f-9598-f3e5f195d342\",\n  \"holder\": \"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\",\n  \"proof\": {\n    \"type\": \"JsonWebSignature2020\",\n    \"created\": \"2025-12-23T16:02:51Z\",\n    \"challenge\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"domain\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"jws\": \"eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..QsdZRqx7X8HcuDD8R55FCpeuGMVLiMZnmZYoKpZ_B1r5FH687Xy15XMwH56gl8-6sGrwU9pdQctdN0afx_dkAg\",\n    \"proofPurpose\": \"authentication\",\n    \"verificationMethod\": \"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\"\n  }\n}]}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{4_1_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/vp-result/{{4_1_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "vp-result",
+                    "{{4_1_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp results V2",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-results/{{4_1_txnId}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-results",
+                    "{{4_1_txnId}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "5.1. invalid nonce or client-id",
+          "item": [
+            {
+              "name": "vp request with invalid nonce",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "",
+                      "var txnId = responseJson.transactionId;",
+                      "var encodedTxnId = btoa(txnId);",
+                      "",
+                      "pm.collectionVariables.set('5_1_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('5_1_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\r\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\r\n    \"responseCodeValidationRequired\": true,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"id_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp submission invalid nonce",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "",
+                      "pm.test(\"Status code is 400\", function () {",
+                      "    pm.response.to.have.status(400);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\"id_credential_query\":[{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"type\":[\"VerifiablePresentation\"],\"verifiableCredential\":[{\"issuanceDate\":\"2025-12-23T10:27:09.133Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"value\":\"MLE\",\"language\":\"eng\"}],\"city\":[{\"value\":\"TEST_CITYeng\",\"language\":\"eng\"}],\"phone\":\"2261640506\",\"fullName\":[{\"value\":\"TEST_FULLNAMEeng\",\"language\":\"eng\"}],\"addressLine1\":[{\"value\":\"TEST_ADDRESSLINE1eng\",\"language\":\"eng\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\"UIN\":\"2042351307\",\"email\":\"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"},\"proof\":{\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"https://api.released.mosip.net/.well-known/ida-public-key.json\",\"type\":\"RsaSignature2018\",\"created\":\"2025-12-23T10:27:09Z\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"},\"id\":\"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\"type\":[\"MOSIPVerifiableCredential\",\"VerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",{\"sec\":\"https://w3id.org/security#\"}],\"issuer\":\"https://api.released.mosip.net/.well-known/ida-controller.json\"}],\"id\":\"urn:uuid:b978c646-8c07-4c1f-9598-f3e5f195d342\",\"holder\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\",\"proof\":{\"type\":\"JsonWebSignature2020\",\"created\":\"2025-12-23T16:02:51Z\",\"challenge\":\"oNjl1LmAXj6pqygwQnMBFQ==\",\"domain\":\"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\"jws\":\"eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..QsdZRqx7X8HcuDD8R55FCpeuGMVLiMZnmZYoKpZ_B1r5FH687Xy15XMwH56gl8-6sGrwU9pdQctdN0afx_dkAg\",\"proofPurpose\":\"authentication\",\"verificationMethod\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\"}}]}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{5_1_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp request with invalid clientId",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "var responseJson = pm.response.json();",
+                      "",
+                      "var txnId = responseJson.transactionId;",
+                      "var encodedTxnId = btoa(txnId);",
+                      "",
+                      "pm.collectionVariables.set('5_1_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('5_1_reqId', responseJson.requestId);",
+                      "",
+                      "pm.test(\"Status code is 201\", function () {",
+                      "    pm.response.to.have.status(201);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n  \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-respons\",\r\n  \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\r\n  \"responseCodeValidationRequired\": true,\r\n   \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"id_credential_query\",\r\n                \"format\": \"ldp_vc\",\r\n                \"meta\": {\r\n                    \"type_values\": [\r\n                        [\r\n                            \"MOSIPVerifiableCredential\"\r\n                        ]\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-request",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-request"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "vp submission invalid clientId",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "",
+                      "pm.test(\"Status code is 400\", function () {",
+                      "    pm.response.to.have.status(400);",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "vp_token",
+                      "value": "{\"id_credential_query\":[{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"type\":[\"VerifiablePresentation\"],\"verifiableCredential\":[{\"issuanceDate\":\"2025-12-23T10:27:09.133Z\",\"credentialSubject\":{\"face\":\"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAFAAPADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwCa9+Keh2g2WKzTv/spgfmcVk3/AMVtYmYrYWEcfbdIdx/oK5mNxGeVGRSmQsSWOATwK+bocFZTS/iXm/N2X4H6NjvFHiLFNqly015K7+9/5Fy+8TeLNTfNxrEig/wxjYB+VVo7MzyeZdSs792c5J/E0hnifrkEdKkikViAWzX0eFyrL8F/DpxT9D47H8QZ3mK/2ivKXz0+7YlSG2iYBc59hU8a7CzMoPPWmL8h4f8AAVIrkybEHXnrXoQtHVbHjyk3qx3B+b1PNP8ALHRaQpxhv0p69QSa1SUHZmXM7gD5fDUcMcqKXblsU8R98Vn7R31Q24pasaI89akiKpwVOPpT1jAAYN9cVIgG4buKfPyq5MU2QrH54OQfbNSxWChQwXPrxU21R1p8ckoO1W+WhPW7Hy2b1uRqgQ4EXHTipFtpEBZACO+TUw+UY6bqaGWIcEsRxSk52swUYy9RqWobgnB/uilWJEfdwadFKD8zE8HGR1pLhos5HCjrjuaTnaNkVGFnqSLCjIdq/hTo4Qg681El1Htzux71HLdhDu83Io5mtRcjZbKI42senWhoVcBfTpVR9Rj2hww96jXVo1fPm44pKcnothqCvqaGAx+/+FMeVU+6+B7VlSa7GrE+avHT5qqz+JrWMHfKPwNJ1ejRSglsbou0PQDjrmka7i2/dANcpd+NLOIZM49uayrz4l6dAdz3oB7DNHtU92Z+zcdUd62oRRxqQck9ajn1aCIcMGyOhPSvL774xWEJOy5XHfDdTWLc/F151by0kPOAegrCWJoResjX2dVx0R7BLrkCrgyKT256VRuPFcEY8uSYAKecGvGrv4lay3EUXXod1UX8T+Jb5iZLooDzhf8APNck85wtNpbs3jgq0ndKx61tDDIIx9aDxjH4GmhVXqKlRVlxwBj9a7k29FoZJJKw0KTjcBz6GpIYvnx7dacqxRcFQT71Ikm0blUfShq794HsSQKDwVqVFy+5e3A4pLd1K7uAfQGnhiDwQcUvacq0EkmShcKKcVBx7VElzG/BPenfaYwTk/TFU6l9Uw5Ik2UVc4Oc09XXv0qr9pGeWH50n2uLOFYY96nnT1e5HLZ2RdWVdx+QYp4kV3Az+dZ76hFGOG5qJ9Zt0XLSjNU59xuDua0lygfay8etKl9DGSgXjtWBceJbaAfPKDVC68c2cQ3mZQMdM1MpKL1Dkidd/aCKAZHyR0WmtqcagjeASeRmvPNR+J2lQEP9qQf8DrGvvjLp6BjFNvx0K81nLEQUrykkaRpyaskeqtq8UZJWbBzzVeXxNbKCJJQNp9eteMXHxjuLtyttE5/3uKoXfj7xHdny4oNo7EHpWNTM8JDVSRrDB130fzPaLrxnZRkh5wBnjms2/wDiTp0CkiaMj1L147JqHiK+LG5vHUex60yDTp5G/f3Tuo6K3SuKtnlCCskbxy6q3c9L1H4u6fAhVZxn0U1j3nxiULsiMjH121yKaBEzgmAH3NWotGJbAjG3uK86pn1Zv3Iq39eh0Ry+O8maM3xO1O6bbHbkAjhiapS+LPE10dgl2Z9DmpF0bAwFx/dqe20cq2DF1HUVz1M4xUr6/cbLBUEtjMe81a7BSa+kB7EelQnSZrr5p5nbB4z6V0dtohJ+SLJHBrRsfBer3ziOz0+WTJ42Rk/yrz6mNxFV+9K5rHD0obKxyA0JdnlBePWrEWjKECkdOgr1Lw7+zh8VPEbrHpfgbUZQwyCLZgD75Nd54a/4J/8Ax51pgJ/DSWit/FcSheKmLxM2rRZTdGD1aPnmDRdwIccZ4qdNJhJ24IPqBX2J4a/4Je+MLlUbXPGFlajHziJGcivQfDv/AATI+HFiiNrniS+unA+YxoEUmt/qGNrLa3qYvG4eLtc+QfNjBpfPUZ2npWQ1/g7nfPvmmf21ECfLI9yTX23MraniPU21myOakjuIkQhmA54rmpfFEcWd0y8dfmqjeePNNhXdLcrj1BqXK+47M7D7dEh5f8jSPqqoced+ted3nxR0q2BKzbu3y1lXnxbhwfJRmPbisZYijDeSLjSqS2R6o2twr1k6VHJ4lgiG/wA0fnXjs3xP1i7GLe22j+8SRms+78R+JrxiwumUegaueeZ4WPU2WDrvoex3PjayjOXuUHuWrPvvibpluuHvU9jvFePz/wBsXYPn3krDuO1FvpEs2N4YkDjNcEs9p9Is6Fl0urPRb34w2SMUhndvdRkVk3/xa1BwTBB7DrWJa+Hh5IGwAnk4FN1bwpe6jZtBZ30luxHyukWST+Nc0s3xMnayiarA04q7uyefxp4qvifLuSgPoM1SuD4g1E/6VeSMp7bsVzw+HXxQ0/M+jfEWASL9611Kw3If+BKwI+oHHoag1H4u6/4Cult/iL4SD2YQ7tV0aQzxqR1LR4DqPfB/CuWpVxdeN1O/zNFChTdpRsdXH4dedQk54HI5q3aaGEkCnPAwB61Z+EvibwV8YpVi8D+Ire5LSBMNIF+Y9Bk4r6R8If8ABP34va/HFPPbWlnFKuUeacHI9sZzXJGOIc7KLZo6tCK+JHznDoZjOfKB3c8dqtw6TIVwBx719l+Fv+CY15tV/EXjmJM/eW3ti5/XFeieGv8AgnD8INJ2y6vfX18R1BYID+X+Nbwy3HTeit6tGUsbh49T8+rfw9O+GETfgOK19K8Ba3qTLHY6VNKx6BIyc/lX6YeG/wBkn4GeGwv2TwLbSFf4p8uf1rtNH+H3hPQsR6P4asbdR08q2Vf5CuinlNVu85L8zJ5jDoj8zvD37LXxj8SYGmeA79lJ+8bdgB+Jr0Lwr/wTt+NmtBGu9OtrNSPmM9wARX6FRWUES7VjUemBipYYYlfbsGSa6Y5PQT96Tf4GMswqPZI+M/DX/BLzU5cPr/jaGIfxrDCXP64r0Lwx/wAE1/hJpoU6zqt7esvXpGD+QNfSgjH3XAOOlPVo1HyrXXDKcJDVxuczxleX2jyjw/8AsZfAbw6BJbeCreZx/FcEuf1rt9A+FvgbQEC6X4XsbcL/AM87dQf5V0aqrfNinbFA3ZrrhQw8LOMbGVSpUmveZVTTLWFCsEagA8ALipY7ZFU5qUjgbeT3pSPk561o3dmV7bDUiUrhjmn7VxtCimqCTjNOBXqKlpLVBa7ufhNP8Yppm8vT4dwxnc3FZd58R/Et5kW6+VzztbrTNM8JTPkxQY44961NP8B6lOwEdm7Y6ELXzlTNMZPSOlz344OjF66mFJrHiLUFYy3brk8gGmxaTeXBEk1zI+RyC5r0fQPgP461px/Zvh67nVzkeXCx/pXoHhj9in4q6yFZ9CW3VuhuZAmKx5sdV7v7zS+GprWx4LYaCTIRsyR+taFv4fbduMQHb6V9YeFf+CeOvTFTrGu21ucciJS5/wAK7zQP+CfHgWwO/Wddurg56RoEB/nQsLjHpZkvFYeK3Ph2Pw7cO22IEj+7itXT/BeozbY4NMeQnphSSa/Qfw1+x78F9CdZX8NfaWX/AJ+JC2f5Cu70H4W+BPDrBdI8JWEAPdLVc/njNdUcqxFRe9O34mMswpr4Uz85tA/Z/wDiV4hIGleD72QN0xatj88V3nhr9hP4x6sqtcaFHaI38VxKFx+HWv0Cg0m0t1Bjt1UDjCrgVwX7QH7S/wAGP2afD3/CSfE7xNHbyPE72Gl24El3elRysUeQTyQNxIUZ5Irop5NDaTbfkYvMal9EkeBeGP8Agm3rTosniHxbbwDGSsMbMR/KvCf22dT+CX7MiP4I8KeM7bUvEccf+kxyTqfIbHRlB+U9+T+FcB+1V/wWq/aX8dvPpXwg0tPAeisxjtxCqXWo3I6bpJmXbCD/AHIxkf8APQ18amz1/wATXM97rkF/d6hqM7zT3VzIVDux3M7SNksSSSSeTXqYTJ8JTnrG7RwYjMcTy6M3fH+ufGb4jXwuLPx+1ujA7UgmaIEHsduOPY8VyDfDf4yRQyS6/wDEKFEPGdR1Auv8zV3xJdeIPDDLollexknARbC2MhyfU5Fc5qVzqOgSPNrF7L9pdciO6iXA/DOa9mpSwMNVF3/A86NXFT0uUNX8EX/hyNrt/F+nXUjqQfsDNhs9iMDj2rofhP8AtxftYfs5yRW3wp+NXiHQ7OIjOnWGqyG1JHQ/Z5N0QP0UVx+peMRLbuGtbaZieCIyuPyNc1ey21yC0rbTnoOa5JypS/ho3h7RaSP0Z+Av/Byr+1F4QuLTSfjR8OPDXjOxhCxzXMavpl9Ko/jMkQeHd9IQD7da+xPgp/wcX/sZfECa3074s+DfFPgGabAa8urVNSslb/rra5lA6cmECvwbMdlkN5nT0o2z20gudOuyHzkgNiuecddtTdaH9YHwl+Nvwg+PHhWPxr8GPiVonifSnIB1DQ9RjuEQ/wB19pJRv9lgD7V1qsgchgTg+lfyc/Cj9oP40fAPxpF4/wDhB8QtY8MayvB1PRL54HkX+7IFO2Rf9lgV9q/UT9gv/g498QafdWngD9u7QkvbCQBE8feHbMC4gP8AeurRBtkX1eHaR/zzbrWMuZPTYZ+xAeF1AEfP0p6jIwUwfUd6wfhf8TPhz8Y/BFh8SPhT4203xFoWpxeZYatpN0s0Eo7gMvRgeCpwynggGuhSPe2SOnWq57qxNrMVI1AB3ZJHNOEbHhcYp6ooGMU9Y1xkCrjZKwabjMBFwO1PjJK0eWT0pR8mFNJtfIm9xRxSbQTupygHqaCMHA60oOVroIu7GgYOQaAuOhqQxngnuKUocZQfpVcsmU5JHwrof7KHwj0dQV8NCc5+9NKT+grstB+FfgbRVBsPCdjEV6MLdS354zXRQQoeFJ+lWorXIDg81gqVGkrxSRtKrUl8TK9jpdlEh8i1RAD91VArSgs49+VTHuRRZwLnOMZNXY48uVH4VpJ7WsRqyeygWMc8jHepYoVDA9T6mkijdcA/pVq2jAYbx+FNyS0EOjhRsEYB96sQ25+ZmJApyW6sQgAHfrXmP7WH7VXw3/Zc+Fmo+O/GeqSGWCFlsdNtcGe7mwdsaA8DJ6seAMn2Li7bIDlP23v27vBH7InhJdKjeDUfF2rQO2iaOTlYgMj7TcbTlYlPbgueB3I/HT42/tReLfH/AIqvPF3jPxDLqeo30ha81PU5eTj7qRqOEQcgKMADtXO/H79ob4mfGbxTrPxU8dX7XGo61N5nzSMVijHCRqTzsUcAcevc15V8OPhb43+OPjSDw5o0Ut1NPIA5RCQgzXTSm6TvDfuZuCqNX+4620+Ivif4h60NH8K+H5b2RTzJEmFT3Jx+pNd14f8Ah5491eBjreuSCOI/vEg4BPpux/Kvqb4EfsPax4N8OW/gzwz4YP2q5j/0+dI/3sv1J4Hp7V79pf8AwTx8Uw2ESXZ0qx2KBtnfOwfgOv0rspLFzd/+Ad/9n0+ROZ+amueGPFVrG6eGNOEEgTa9xtMj9P7xryLxb8KfibPcSX17YXVyWbmZoz+ea/XbxJ+yTfeHc2+j31jqkijDyWVvI6A/XbivJ/iH8A9e/eafqe5IweQEwPy4qa9CtGN5bDjgor4T8sNS8MeI9Lk8uWBs46LzWXc2WooczxEE9M196+NP2WNHLS3kHmBj13Kp/Qc14j45/Z5ul1AvBZHy4gRlRyfrXmzbgrsHg6vQ+dFguFH+rPTrTW8+M5HGD3r1fUfhNc2cgjMIUnuKp3PwnMyfMnzY5NYTxVJbk/Uq7R5v9vlU/vBuHoRT01CWEia3Yhcjcprs7v4QX0KF1BI+nSsW/wDh5q1vCZIonOPUURxFGa3M5YetDdH0L/wTm/4Ke/G7/gn78Q01XwbfPqnhHU7tX8VeCbicrb364CmWInPkXKqBtkA52hXDLwP3+/Yp/bu+Af7dfgubxd8E/EYeSzSNtS0e7IS9sd2QBLFnI5UjIyp4IJBBP8rF5a3dhP5VwCpz0r1r9j79rr4y/sffHHSfjh8GdbFvq+nb45LW4Uvb39u4xJbzICN6MMcZyCFYYIFaON43Wxi07n9XiIAOTmnxhQcH0rw/9hP9trwX+3B8G9O+I+g6T/ZepizhOv6NJcK5sblw2UU5y6Eo21iAcDB5Br3fyY3XcgFNRdrkOxECoIA709IS0mG6YqVYIy2GQDApVjZX+X06mlzT2Y9tiIwDORSRw7uvUVYWNmI4607yQMnHXrWnIpaoSdmRIjk4YcjpTguec08IR044p8SLg7xjHSm7LZkzbtax8zRWxXBxzjmrkcKpGDjtzTra3cttcc1ZNqR8p71zy5UajLaENyKspBhg2Kfb2yIOKuQ2e5N2R+dEkrbANtYN5wBVxLHeCWJGD0pbW1Cr8pwfWr0UWFG3k45PrUaSle1x3ZWeELD5jZGFOCRzX49f8Fa/jzqfxo+M0ngTSNHW20Lw8zRJctIWkvp8ndLgcIgGFUdTyT1AH6o/tOeN0+Hvwd1bxBLemCVbZkhdGIO8jAwRX4o/FjUJ73X5WnhM8txN99weBnFejgsNztyexjUqKLSZ5BqHh9vEVolichQRHBGqcnH86/SD/glJ+xBoXhXwsvjbXdPH9o32Ms8eCoPYZ6fXrzXzD8BPg2us+KYbieITO0oEcePuL6e+a/WT9lzwvH4ftLDTZFVYoUTIJxk9TXoRw7U02jvy+EZty6I9b8G/BvRtBsoo7TQ445JV48tOevUmvTPCPwN8Lx2rTanp0c7SYJa6QOc+gz93HrXS+GNMtGt479Y0OVyMdq1vMiJaZpNipxivoKVPlSOPFYqd3ZnD+LPgzoa2LHSyowMhBCOn1r5W/aV+EegRW7Xt7AkgZSVJXng854r6r+JnxSsNBsjBp9+sbuSv73gvwSQo78Cvkv8AaZ+J+o3mgz2GnTmCOSJ0aUqC3PpnpSxMYOjLmRvl1SrKor7M+Nfil4S0dbnzdPtzEMHKqeM15R4q0iFImSayWQHhiR1r1PxTdaldzkNcEqMgZNc7Foq6huF0m7aecivicRGUpe6fV8kFFXPBfFfww0m5IuRbBC4yoC9Kw0+FViUMbRfPnqF61714s8IRSpvhiAGPl+lczc6fa6bCInTL4yWxXnVac1KzHyQPGtY+GM2mxEi3DKRxgciuVv8AwhEyNG8QGOvHNe5a1dRSRMEAzjHNcDrdlbmVmYck9hXnyVtET7KPU8C+JnwqjvbeS7sYAsiKWGB1rx9ftNpdG3lUq6vzz0r6z8R2UXlunl8YxjFfOXxV0H+y/Er3EaYSZi3FehgqzT9m2eLmGHVudI+o/wDgmH+278Rv2W/ifb3/AIK1g3Mt8yWl3p90jPDNCzdwOcqeQw5GW9TX9HPw48YaX418LWPiHRtZi1GK4t1YXVuQY3OOcY6c5GO2K/kZ8La5caFfpdWk7x4H+sjcqQfqK/d//ggl+0v8Rvin8El0XWPElnq6aTdG2lsxMTdW6EnY0oJOdwHyt8u4A9SDXetLpnkSep+liIJOpwcU9I2VdrnI9aLGWDULZZ4lwSSGDDBBHUVO8QUbQM5puLWxl8QxVUjco6ClEWVzj8aesQVRhfqKcoCtncfpQptLUpf3SIxjqBx700x5PA/OrDKWpBGUOQKpWe6Fa73PngQBMHbk96trbqVz/kUsMGO1WEixxjiueCjzNs3aI7a2ZiAEznvV4QxQ/KUyafZ24UbifwxVoLjkKDQ4pXsDdxltCNnPWrcVuRtJGPUim2cQdsMCcGtCKNSxVxkduKdOPYOh8w/8FNUZfg5G5unijafJ25A4U/45/Cvy2aDTfEupxbm8yWMsTgenQGv1X/4KsaesX7JOsa5LqBhhsWSaRQcB+cBWPYc9B16d6/Jn9mXw34g+Ifj5bTRd8xup1GwA8AnFezgcTCMXFnNUoynUTTPqH9ij4RXus+K47m1hcxxOskkpX7uK++Ph9Yx6ZrMdtHmQcAh+Oa474GfBnT/hB4GgsVhVLqWJGuXA5DY5r0H4fac+q6+rwT5WJsyMxwDXTTc6lZRPoKFNYfDNn0X4W1C/utIRrRY4fLUDaTxWgh1AZN+iOH58ssaqeFYtLs9D/tP7SkqDr5bggH0z0rG8SfFfQdOBlvLyGFR90tKM4/Cvp6VJxhZHy+IqwlV3Mr4raNaJp7XRijKtzgDGz8f89K+KP2gb3UtbvpoLe1YRQsckDH519LfEv48+GNSj8qx1SOWOI5KuwAJ9s183/EXW9E1W7ubk6iVVycxgDnvXHj+edPlPZyzkjK7+R83eJreePUCggbJbhQOlU2s5lXfGpBH3xiu48SppMM8l3HcGRmk+6xHFU77TreexWaDCtKcAj+tfKyotM+mjUaSTPPvEO9YCoXgLziuA8Rx3TxbrS0aQkcADmvWdY06ySMKrhyR82a5PxDpcEeBC20AcYrzcZRvZI2Una7PFfEP2+JWjaB0kB5VhXPXEE0qBmXnPPvXo3ifTDNellAwOK5bWrNbCMjyc84yK8WpT5XoYyldnDeJLeDyydpLY9K8O+MuimQmVo8MOmO3tX0Brdt5qHyxhsc5715R8WtGkns2maPJU/NtGaKStUTZy4qPNSaPBvmQhSvfmvuv/AIIOftUXf7PX7Z2kaDHq1vbaf4zC6RqQvEUxSKSWjDEspQh8YYE8nBBBr4h1W2+yTsxB+Y8YrtP2ZvEE/hn40+GvEMdxJELHWraaUxRCQ7FlUt8p68DpzXuKT5Lo+Zeh/XRp00FxbpcojLvUHawwelWCM8muV+CAMvwy0a6bU0vfN06FxcxPuSQFFOV9B7V1wTcMgU00lZ7mbdncjx3xSbec1IYj2FJtPc1bjdakOWt0NpwQY5owAcDmnAFRg1Kck9Cm1e54JDG+/YGP41eitwQO2fSoIYtx24q/CgAAI6dKzi3zXN2OtkCfKfmHpVoJCwCoMZ7Y6U2CEFtyEcDmrENuuSwOSDxmmm7WEOt7cqMLxjqfWrcY+XAFMiixlscmrdvFuj3YGe9aRvsgeh8yf8FcPDket/sM+LxLcKBaQx3ccZHMrxtlUH4nP0U18Vf8EXPhKviDUNX+It/Cjw6aEht2bq0rZJ/IDP4197f8FPBYRfsQ+P8A7YTtfw7cxrtHRnjKgk4OFGeTXz1/wS88KH4XfsX6Lqpt1judfkmv3Kjll3lEz/wFevfNbUINzujowkeeqj6U8VeItPtQYi4wq4fHYV83/G/9sG58D2l5oXgyOVI5GKTXTNsKjOPlI7/410vxW+Ldn4fsbmWXJlkQlMn73HWviP43+LdY8YvcNpeosq7iDH5YKnPXmvcw3JSXtJfF0OnHznJezjsdLr37bfxasfD9xYXPxhu9J0+C6M9rbrq0rSeaP4gu7k9ueK84H/BS74niRIrTxFJq06PiWOW5IcjucE7c/QV434l+FGu6h5+pR6jEjsT5kT55+hrzTWPghc/amuY9Ukt5t2WdWOAfapqZtWT91s8qOBe/IfVV3/wVIvLq6k0rxHp9/aMzgN5vTP1GBj6V2PhL9sXw94pVbew1pXZlHJfpmvh9fDniTTz/AGXrlxDqllKMM0yYkXtkH2rL0HSdf8Fak0llM7IZcxuO4rjrY+vW0lK520XUw+0dD9FpPiOl4yv9qVgefvVoD4jmOzCyzsEIwBXyr8M/iNqd5b29lez5kdvmct0HpXoGu+PbfTrIRzTnEY7d/pXK21rc92lX9rDY9P1nxzFaxGcTJtxkBnridV+KVrM7v9pOc8L2rxv4kfHK3sdPM005VTyhryDXf2iLmbIs59uR1Dc1zzj7RbmFbGxpuzZ9SP4riurszmZTuBxzximXus6NdQFbmWEcZ27x1r5X0L9puexiOm6lCzo3WVeStN1fxz4h1NP7Q0PXBcRyHKqrYdR6EetYPDU1GxzSzCN9EfQ2s2FlfWj3enTrIFU7gD0PavP9R0x9XElhNCBuBDexrz3wb8YvEvhW/I1NJpopG+eJ+Pxr1bwT4i8P+NZ/tdnLtc/6yJ8Bga86vSSkuQ6KOIjXjZ7nzv8AFDwnP4e1eSwMXyljsbsRWx+yd4W1LxL+0P4R0LT7eZ5LrXraJfs8XmSLukALBMjftGWIyMhTXp/7WPgq20rwzp/iOC2AxIEdgOTkH/Cvo/8A4Ny/2Y7b4xftm/8ACzNTgl+yeA9MbUUzErRvcyZhiVt4I6NIeOcgEHjjso3cNdDyMVTjTqNI/eb4ReBrX4dfDTRPBNgcpYafFEZGTaXIUZYg9CTziumKlE45IPNOhTYg3AYUYBFPKhhXXy21SOFfgMI4yOh6U0qDUyxsF9qAikcUk29xPYrOhU5XrmniKRz8op7Kd+MU+MhOc1pyNBzK2p4Vbwkk84GeM1aSMqR/F9ajiCZ3BRx1qeNxu3EYrKacYvU6CeCMrlwAM9cCrcCqQMGoIGDsMscHsBVuNV2kr0HSiMNAJoo2bgHNSmUQgRZwzsADUUTlF3Bq+fP+ClHxL8dfDL4C/wDCU+BNYlsrqK6yZ4gMqNp9ffFO8Ury2OnB4d4vFRop2uza/wCCm+galL+xr440SaJY57nQJHsmdSyTMMN5a7erMAVA6ZIrzTwT4d/4Vv8ACfQPh/aoANF0O3tHVRgZjiVW4HqwJrw34H/t8fEn48eEoPgv8S9l62p6hbWhuWQ7HUyoDhScBiM8A+/tX1VZ+EbrWHS3Jy03ysWHQGvTw8KMqalRldM9mpl/9n4qUJdD4S/ae+KM2la1dqo/dxuV2ucYFfJfxK/ad0rQI3SytNxGR8jDGfc1+yPxD/4JWeBPiNpD61c+LZUubhh58T2gZdhHIBzkH3r5c+Of/BET9mnSLaS8k1nWfNDbin2gmLPfIHOP1/lXY8ux1SN01b1PPqYrDXtB6/M/LfUvjl8RPE9nd6rologtLVC008zkLgc8etcM3x/8fySbGERB6EoDx619n/GT/gm74Z8A+Gp9M8GfEK+WG7RhPaXrJKijopGFRh+JNfHvi74EeKPBV5Lpsd1FMit8zRrgnHfnp9K86th6uHl7/wDmc31jEyejf3Fg/EDxcLW31HUrWGSGdN0bquNw7jNbGleNbTUlBdChJA2N2rnrvWZrTwpb+GH0XesB+ViejdzT/h94K8V+N/Edr4f0DTpZry6nVYkUE8k4yT6VxTcOb3dzqozrte/rc+ivg38EvG/iuwbWtD0aWW2UbnmK8AeuaqfEbTfEWiaj/Z+oQOqKpyK/X/8A4J+/syeDPD37M+o2Gs6Yr3FpoxBJT+LyyST+I6+9fnn+2j4BtdN1q+uLBIwUlYERtwB7frXXi8O6GCjU5tz0KEeecopWsfH3jHSdO12IjUJ8xxnAjJ61yE/g7wZv8swoFHcsc1p+NtWeCW4lEpAR8fjXHWli2vx3N3dakP3cbFYyx+Y4yK86nJ1lvY8/ERp05bXOo0z4a+CNTJIYNg/wP0q0Pg5p9rN5ukzOE6/K+P8A9deVaYmoMXe31aWIB8bQxzn6V6Hpmk+PdB8Cp4+sfFgliSUpLaTvljg9Rn+VdPK1GxxqeHnLVW9DrfDujWuhyiTVtLLo33jMN1dN4GsPD6eNI9Y0ZWjQHBi2kD6c1xXg34zWviG2W11myWTsw7g16X4Qm0eWRJrWBVHUVxzWp3QjGSXLr+Zp/tY2I1D4H/2ko+W21KFSvfnj+or9T/8Ag23+CS+BP2RtR+Jt7pxju/E2qjY0ignyod4BBIyAdwPHHHr0/MH4owHxD8CvEemR2zzTIkNxbxIuSzRyo2B7kAiv2q/Yu/aB/Y//AGWPgX8PP2QPE/7TvgxfF2jaDa2FzY/2whdrlhuIdh8kbsz8K7A8gc8EzS956M5sbCSmrK59YxL83DcDsakCgHANMCgHCuB7g808Oo45zXf5NHmWTYpJxtIoCZO1evvSk8ZPU9KRMEncR0rPaVgaY14/myRQU3dKeAp4x2piyFfm71asxadjw2FdoweoqZCpGAarQyBl+Q81LAc4G0fWsp2jZHQXYHZE+U455NXo2ymcAA9Kz45QpEW0HPSrULOwCAjHbmq2W4FtDxxXzd/wU/8ACeseKPgTHbaWjyReewuUXoBtBB/Q19Ho5HFcb+0B4Sg8afC2/wBClOC+0q3pgjP6E1NNKrLkfU7cur/VcdCr2Z8LfsyfCDQPh98KPAc+qWccuta54tudRjkJwy28aPEo59493/Aq+1/CNg32uK4WVQOCTt6V4D8TPAMHg/4wfDuz0y5Z7HT7GWBUUcBhC/p/tcmvefC+ptJbK0YG4AZ9PpX0WGoRpRjHltY9/M6sauJlN/aPoTwVptpq+l+W96m0AblzzXG/HX4P6bHpk8l3IojkBIO0YI7jmsXwX8RorHUDBLqSRXAAKxMww4/u81N8Ste+Kni7Q5bf+z1EDFvKkLjpzgc817MJS5bI+aq4eUKvZH57ftU/CTw1rV3PaaZ4kntVKsJBA43cdOua+LfH37MlpBLLNbeKLq6Jck+Yq8nPsK/Sb4i/s8+K9Wu5U102kTSMxbDkkL2BqD4bfsj/AAyN/DJr0S3jyMP9aPlxnt714uIw9XEVUrWPZpqlTp3vc/OP4Of8E+PGvxn1nGiaBcNZRkfabx4zsTt97HX6V9l/sw/8E8/CXwq1wXg0SM3hZcysu5hj3Ir9F/AXwk+F/g/wjNofha0tLaO2tvNdIlGEXkZJ9yK8vGp6ZF4iluLC2UDftGB79f8APrXRLLaFCmur7mOFqKrVcrbbHd/ATw5/ZHhPxHolnaRhJdNMeMc52kY/LP5V+Wn7b3w/htfE2rWNu7HyppEYEckg8/rkfhX6sfBrSNa1W7vks2kWGRPnZehPPGfxr4T/AOCgnhCwsPiFqNi0K+csjCRgoG3Izjj3qMxoc+AtFbHdgpJ42Sb3R+QfxL8CkXUkqQs0TMcrjvXEx+EIrZmkjib3Wvpf4g+F4rPV7i1cBl3ntxiuYPwjfV1E+nFRn+Hsa+EjKVGdnqTXwyqSueMWfgTS5U3FTHI3IIyDWpB4Ohe1FrdXJkjXohkO0fga9Rk+AviTOVsd2OOKVPgh4jR/3unMuPvE8V01azlG1mc0cCoyvbc8ytPBWnWcoe1gVT2KgV3/AIGglhRYz9wEbjmtuL4R3sEBEkS+pPermleDBaECNSGHQYyK4pzm7RTOmNCMOh1FrZi68Fazbq33tLn2gc5+QkVhxtB4Q062tV05ZiwAkEnRgeufWuq0W2OnaBeSzLtVbKQsT6BTXI+OL2W51bT7e2Ct9oSLBB65qoxVryR1YOClVZ+/f/BOzxtqXxC/Yk+G3iXWdSkvLs+HFt7i6mcs7tbyyW+Sx5Y/uhyete1s24hycn1rwz/gm7ok3hn9hP4W6bcwCOR/CsVyQO4neSdSfcrID+Ne3GU4xXt0mnTVj43GKMcVJLuSiTHLdzTpCpk3LVcyZPI6CnCQ9jRJWWpjo9icSADOeaY5xjbzkc02NlL5bpigODkjp2pxSsU/dR4NbSPGM5AB9DVmOUDBPArLWdGwAMY7VagkZvn349qxko810bGnC7GQPnpxVlHAYODz9azoHA6Pj2q3HIDjNU7SjqBoRSmTDGTP1rO8eW93eeEr63s1VpjCTCD0JqxGyMMbAKnzHLF5ZUNkYwaKaalcL2dz5i+KOt39r4K0XxddzRyxp4mjtYlKAtE7wyhhnqB8tdr8NtdN5BuTDljzg9K4f9qjQ7/wh4UvLGCxeazj1+31GEKThAzGNuOnG8/nTvhR4v09JILaykA3JnYx7/Wvq8PNVKcZI7qmIlUake66SbS2je8/saORlYMXUfMfb3rT8V/FY23h/wCzrbJa8ZKKMEfXn+teY6x8Tm0ZGhSdcspBXPBryD4s/GxGQ20dwdi8GJWwc1vGsqV2zRQddrmOn8dfFKOe+mWa9/1rEbiccdzXEeJvjW+jxJbaJOEWHGHJHJx2ryfxH8UrzVbwso3DOMMeB+VcnruvNK7zyylpW6IvQVw1cRf4dT16MEtz3fwR+1B4tsNVXTLGaS7uL2QRFd5JI7D6DJr6c8HfDDXNL8Px6/4z1S0tIige4nnuFUjPOBXwh8JdE8U6TInxH1LTnMFoTJCjKfm4PIrwf9s3/gpL8VdJuJrHw+LmZxJtSAysERR6gf561l9cdGF63yLlCDu4WVtz9ZNX/bn8F/DDTLrw74Gv4JGAO+4OMufQZ7V8A/tS/Hyfxx4wvNZvLsu90zMzKeuetfGXwf8A28PG/jLW/sPjPwzPbrISFuYpCVz6HcBXU+PPjPp2i6bceI9eZpVVSyeWu5m74AFZYnH/AFjD8sdDHCzwtKbmld92N+IVlcXrm/tTu3nOCcVP8Lr+N70abdRqsg7E1578PP2qfA3xFvzocthdWU27EbXKLg/iDxXXQXtppPiiOdCuG6sDXzM6Mo1brqdEalOp70We42mn2TRJtVc45AFS33h7Tr2IttAAHIAHNc9oXiiCeACIfw/fzxW0mrW7QKYjzjmu/l0uW5JqxzWt+FYIgzxKTu4VTWCfD5tpiGC5BwTmu0urqS4dmIBwMDFYM0RN032gcls8V5tWknPbcwnN7GD4mQweEtWjRBkafMpU98oR/WuV8B+A9e+LnxL8GfD3w8xGpazeW2nWTYJ2STSrEjfQFgT7Cuu+IVxFZaPJED/x8yLGB6gkZ/SvZv8Agj58Mk+JX7fuj+IG0pp9O8F6Xc6nMVUFIZjG0FuWJ775GZR1zHntUyg1aIqWIhQjOb6I/afwj4a0fwR4W0vwZ4ei8vT9I06CxsY/7sMUaxoP++VFaDN/CKhSTHQDkcnNOM8YHXn0r04baHyFVuUuZ9STcQP604PxycVXE4YkB/wp3nBR83X2qnFWM00WFZSuCaQuV6VAsvOCaSS5IbaDWcZt6Daa1PAvMTPBqe3mCMC3PtWSlzt5z16Vbgm3AMxquXm6HRsa8F5G0gAXAqyk+ZMKeM8VjxyDPXNWEnwcFv8A61N8tg2NcXBQ4qWKcryrkGsm3uSJSCcgdM1cjl3HzCMUoN8zXQTseffta+C9S8YfB3U5dEVZbuztDcNC+B5scZDsufX5cj1Ix3r5p8C6vJpWj2msxMJUWHezpklQOn8q+0NdihutIuIblMxvEwdcD5hjpzXxDo7LZabqHhCIx40rVZ7Z3ikyGAkI+939c16+X1Z6wexcG27Fvxn8S21i1N9o16roM7yjZ2kdR9a8c8S+LL3XL0x+ew2t8xyeB6111nocWj3t3oumwgwXLGXchzgkd/euM1rS3tpJ12ECP77YrTFylGzPXwrTjYqaba3mv6nHpuk2DSOxwZWcAV9Lfs/fsjeFLq4g1z4g3yMxAb7MzjaMdzXyJH8edJ8H6+NNs4Ve67yN0Q/412cf7RHifXbe2RNcYx5xIqSY3ducVeB+qyalU/4BOLxNSmuWB+hbfDj4ZHTJba1mtmtbZNu1IwyhccAD1r85P2/v2GvAN54pufGPwm8Urb3lwxebSZo90ef7wb+HvkfT1r2TwL8U9Xn02KzTVvLht5wS0kx2hfTGaTUPGP7KHhBtR1P4ifECbVp7ycu1rp0QLqxHcswXOe+fwr360ctxFDlnZL7jyac8yVTmgn+Z+XXi/wAG+KPhjdRpremQeXM3yy25yvWsrWfHKxYtWja5XhRG5JABHP0r7M+Ntj+zp8atWNp4X1afTlWQ/Z4r11LPzxk8V5x8Rv2bP2a9B8KOB4/mh14rk+XIrRZwMLsxkd+/evi8TRVOclBrlXme7TpY6cE7a+h81JceEBdifSNFhgnDgsSoBDe1d5omp3d4ge6mDHIwAa4nWPhqyXzy6VcCQI/EiHrWjpDa/oMg8+LemMlweRXiTk5StE0hOdN2qHsvhvxRHZWkccrFewya6rTfFckswhRuCOx4rxTQviLYz3P9mX4aMkHDEda67wfq7teBFuSY+oNdEK84pRnr6GinGbvFnrEOphULyvjI6j1qjLqSwI08zhsfxE81lvcyOEkW4+Qj5lz3qtqF/FMfsq8kjnmt5J6OJlUmooreJLy31/UbS3dx5YJJx2IH/wBev1j/AOCQf7LDfAH4AHx3r0IXWvG0keo3Z2nclttP2aM59EYsf9qRq/O79jD9jnxX+1l8ZrPw7pGnXK+HrJ0k8U6yFPlWlsSSU3ngyyBWRFHPO7oCa/bnSLOz0jT4dJ020SG3tYVihiQYEaKAFUewAAqKdNuV2ebi8SlR5U9Xuafm4GAw59TTGcEbie9VpHRQHHJz0pWmB6qMeldN0eRfmZa85e1C3RHfiqbTEqVU496EcsMuxHsKHorIltrcui5XoppGkPmbieMVW3RgZU80nnsq8k49qzUVdNjUr9bnzuLpyBjOB0q9Z3DGIGTt0FYqXDyfKVwfStC3mLwbAea06anTc1oblWcA8E9KtZyMgism3mKuAzZx0Iq7Dcbh8zD86nVRBvWxbWcxDJ5+lTQamsUBmnOB1HtVMFSPavlv/gr9+0vrP7Nn7Hep33hHW1ste8R3SaRpMyTbZYjICZZExzuSMMc9iRRHmsrA7LU8D/4KQf8ABVzxFrfjnUfgJ+zR4j+yaTYQvba74rtpf3k85yJI4CPuqn3S45LE4xgGvM/2IPi7f6r4Iv8AQNT1k3EtpdguJZi7SIQMPyc56g59K+FdFdra3KGWZ5JEy8zEkuT1rv8A9mH4m3fw5+Leni7m8mxvm+z3W/hcHocexx+deph5QoRu9zjjUlKrd7H6a2Fy8Tia0bPmxjduH3c1meJtOgFnMjqCZOWFYWl+MJQkQd8s3OVxyO1WPEfiJZbYsXIBHJ9q2xE1KN0fR4Szdz5u+OHhG80zXJL7QkJknXai9gxPWvLJPCn7VWjyvdeFfDF9qUMQ3vHayZIA5+6etfSt+bbWtajW/RdivlSR/jXX3kc9tp6ropRMgb3I7d686CU5Xk9PI6KlDnk3HQ+V4tS/bu1q2bRYfhF4t8tY1kK6dpjSEqc/xJknoc4rjPEvin4seDrML40+GvibT97MwuNS8P3UQOBzgugz09a+07L4wa/8OrpdSi1EqUHyjA5HpXo+m/8ABQrwXq3gm98LeKfBem389xDsEt7IGYdyQDwD0r1oYDAVafN7Zp+ZkpYunNRtdeR+WN18aUju1vrm8uEZWB2NCRg59MVn3HxY067uJr+61SQNIxPzEmvqX4x2nwY8eLPHd+C9PjdmIWaCFUdMnnkda8W8Rfs7+B7Sza/smZIskoszBgw9fWvBrU60JPlfMj1Xh58vxWOF0b4k2bzCaw1D58ZPmNj9K6SH4r6Fc2Zj1LZHJn/WKRj8a5rUPCOg6fOEtLONiO4HWptP+GcOvSq15YiKAMCFUYzXFdNO8Thl7aMrJ3NpdU07Xp45LKMbVGFkUfe967nwPb30GPOmYoo+UntWBY+FYdJiVbO1VUUgKAK7fwrC5g8plCk1nzJip0+R3Om02YyWLI8nQ8ZqCcuJB5CknHzMfX2p9rCpkS2Tg9WJPFdJ8P8A4dax8YPip4b+DnhWRUvvEWqxWkchGRDGeZJT7JGHb/gNdEYy5LLcxrzimz9Uf+CSfw6uvAH7HmianqluUuPEMr6nIGj2kJKfkB9cIF5r6gLqMCuf8H6Bp/gzwnpvg7SUMdppdjDa2yMckRxoEUH14UVrefuA9q6Vde7c+fm05XLJlXHB59Ka0pVdx9fSq4ZhJvBpWui77do9zTs76kRSfUsCZX5BwKeki9jmqhkXG0HNPSRET5jRNNhFK5ZZtxyaazMPunmohP8ALwetMNwzf/rqY2G1Z6HzbZ3Ts5LP3wDmtW2cKmwsT9aw7aPE5LA4zmtaKYKy5zg9aXvXubtRtc0IJMYUAVZhG45PUVSQMXwgA981bhbyfvtyaqMVYV3Yv20hztboR+VfkJ/wcUeKtZuv2hvAPhLUtS/4lNn4VmurO1TORPJcMkjkdCSsaAHtg1+udu5MocAkjsK/Ff8A4OD/ABCtx+25p2imPcLHwRZABzwpea4Y449Nvf0pN8rQpXjHQ+UrHxFe2drBdm2RgxAC7ucdqqazqOraxrEflSrEUUuqqfukdCfeuf0XxBdRyJa2SqZM4V2P3av3l0LO5EnnF5WwZETngdq7lVclZvQ89Lldz7s/Zb+NkPxB8Fafa6neH7bYx/Z7oN/eHCsfqBmvWNWvLlSIroEIR8pHSvlP/gn94T1H4ieGfiDqyo8dxpK6dPYqCfut9pDrx14jT6fjX0X4Y8VxeK9JEkQK4jwUc8qw7f59K0lJOCVz6DBTnyq5LPDFHKLt2wFPy8VYk8TziJojMT6ZqKSFmTAi3+iVq6P8PLrWYUZLchjyfauVuUHqevCXMjzD4najqU1q78thMAA9OK8R13Vr2KJoyHZxks4JyK+1rf4I2WvO2nXEStJ0Kkc5rR1//gl94M8QeFZfEmpeM20u+KZht49u0kg43bhnHrjmtIYevX+BXFOrGkrs/OfVPGGsWbNC1xcupbJ2n/Oat6V4pn8RwfZ57mYKgA2k8c11nxv/AGb/ABH8OfEs1jNMl5bpIRFdwnKsM1geH/C1xYj5Ihy3PHNccpxpzcJXuOE8U3e6sW9N8PaTbkXTwhgTjLsODXQ22nwsVSFQuwcccVnPo32kBLlDtRwQQcVoFXByhIAHTHWuOrWpT0Ww/fWpLPHEGVV5I6mr+nXAtpAmQtURCPJVgxBIyKdaOInE0kpyvbFZ+4tkJ3e51C3SoVnKg5T7ue9faP8AwRX+AcvjX4j65+0t4j0zdY6HG2leHWkXg3jhWnkH+5EyoD/01b0r4Z0PT/EvxF8Y6P8ADDwFZi413xFqEdhpVuXxvmkOFz6KOST2AJ7V+6v7MPwI8Ofs0fA/w/8AB3w0Fkj0exVLu6CBWu7phmadsdWdyzfQgdq7KMnY8nH1LKyPRBwcjkDrTt5AwpqNJS3GOMU1GY5DdK1VnqjyGkrXJfOk2fLj35pqzMG+YGoSxRvl6E1IGBXdnmno+oNyT0Jwd7blPFO2g4J6VBG+4ZPH9afneAfSlKUrXQ7EwYAfL6UIRjkYqJWI60jTgGmrbhPQ+c4QDJk9ew9KuxEhwA3PrUEQTzN2wCrIC7wx70b7m+pfhPyhmY5PepAScEnODxmqyBgQGbp0FWITyA449BS5ktA5b7l+Ns4KHBzX4z/8HB3gzRoP2ydB8Ry3TxtqvgmH7WdpxvinlRSPX5SB+Ar9l42VwFEYHvX5Bf8ABx5ZQRftA/DwxySBpvCNwz7gNuPtRAx78fyo5kTJPlPzvL2emy+Vpd2dx6ykYwK9p+EH7Pskuhx+OfiDevY2M6ebDBINs9yuMhueVQ+vft1zSfs1/ATSI7L/AIW98QLMTWEJ/wCJPp86ZS7YZzI4PBQHgD+Ig9hzB8dvjpqGtalNbQXD85BKv0r6PA4CnCj9YxOkei7+Z4OJxM6lT2dDfq+x9pf8E3NY0XxPdeO/C3h2xjhtNMs9PMcEKDB8w3QLH1P7vvVL436VqPwV8Wf8JDpMO3SbyXFxHjiF88H2BrE/4IUpLqEfxQ1e5lLGR9HgXceyret/7PX1F8ffhlpninR7vS7+1V4Z4zkY5Ge/+elceLqfW580VZdD63LcK6eDSbuz5SuPi81veW+phmkUtl/nG0AHke5r3b4c/Gbwxf6XG7TCJ3Xdhv4favjP40+E/FXwl1R9IugzWZkZrG5ViQB/dOe+K4Wf41+KNMmitpdRcQgeWpBGRXJGcI6bjdarRnqfpGvxx0iC9Emm3EJlifBbIJIrB8aftJ6reJJ/aGo7hGu1USTgZ9MV+fdx8fteimEzXrhFGFKtx1/WtnT/AIw6jfwhbjVSxlO9AXrX6w4R5YmsMa5PVHu3jH4qaVrry6VqFr5qbh8zc5NcnNpVpby+dZoBHKCVGc4FcGniQ6iUlM/7wc7hwOtX7r4hPZWZibZwhAJauSUYyd5bnS8S7aGlcazZWMpBYbM4YYqxHquhyRm5W4TaO+RXkWteOZFaRRcL5kkoYbjwB6Vj678R5RELC0lIZz8zL2rzauFi5cxn9dR6Z4h8b2a3rR2k3yK2MkgUo8VQpbK5dcnkEGvONPvFEHn3FwshYZcuas6ddyaxKIbXIgQ43Z61lNcurCOInPY6W98a+MPAstx8XPCfiO60vVdFKXGjX1lLsltplIxKjdiPy6561+1v/BIn/go3Yft//AA3Piy7toviD4UEVr4wsoECC4DAiG+jQdElCncBwkiuvTbn8M/iXO1t4AvbLaADDgfTIrX/AOCWH7Xt5+xz+2H4V+KFzqkkGgXN0NM8VxhzsfTbh1WVmHfyzsmHvF710YOp7SLR5+YUnTmmf00MSpBVuO2KPtCldoPSoTOpz5cisvZlPBHqKjKuj7hjn0rrSsec09yxk1IpXABPUc1V+0gHcTwDjj1qUPjBY80pNW1LSklZErMQ4TOAOKk8wJjacj19ar+bu4JpyvyFPQVG/QHuWPNVyNp7d6bIEB+b+VMJAbINBnwclQfTmiTsrIbbbPAIlbjPpzU6EBxk9Kbgv9wYwecVNbpHj515q3e5sWYyNofPJ6VLExJ3d6hiT5irdulW0iUpuXseaTS3sCLELkD5jXwN/wAFyv2Z7f4x6X8M/H32V1XR9Zu7LV7uNwNllNGku0erF4cD03Ma+8NV1zRNC059U17VbWyt413ST3U6xoo9SWwBXwF/wUY/aJ074teK7bwZ4R1MXGh6IhZJYmOy4uXHzOPUKMKD7t2NenlOBePxkY291av0ODMMVDDYaTvq9j4o+Neuronh1dI0WEQW1rbCO2ijGQiAYA+mBXyn4gvZL6/e4ll3MzV9HfHIXEmkTnzCBHGTmvmS4lyxdhkknkV7fEU4RqxhT+FI8nJoScHOe5+kX/BCvTmT4cePNWUEGbX7SAse+yBm4/7+fr+f2v4ptPtgezEmCM7WI6n0+hr5o/4I5+ApfB37Nr6i0R3atqbX8oZcHDoiD/x2Na+oddtjKryQ4Klso2ea8enzRpq593gbKnZHzh+0F8IdG8Z6NcWV/YIflIZMfNG3OD/9evgD4z/BjW/h1qkqXSG5tMkxT4+YD0r9UfE9naX8EkV5uSdciOcD9CO4r54+Nfwys9Thmt720RXYEqduUb6elctenbVG9fDwqrXc/O8adNcwP5dwxVQSEPar/hszpGrMhIQbcEdK774lfCldE1Wa40osqMx3LjpXKwWeqWVuYooVb5v4lxXF7RJpM8ueGqQepdg17VVQWcERII6msTxF4g8RJMIxDIY8YJbOAa3RrF1bMC+kkttwdjZ/H2qjftqV4S0Glbg2D+8OAP8AGhysNJyVrnLXMGp3sqGXjjnJ6VZsW0+0YrOvmSAY5GcmtaPwdr2oP59w3lR9/L5NdDoHw+slUTRqTIhHLjk1nKvFRuRChOcrIwPDeh6hrk7NdWzwxBx8pXk13ul6BDptvuWMKi+3WtDTtKtrOMzNjcedvaoNTvmKMA+B2Aryqs5zld7HrUcPGlHzOJ+LuoLLoU8aNtDoQADXjunyKG9AeGAOM9q9K+Kt462LRA/f5rzK2VSBg9DXdgEopnmZjJynofq5+w5/wcAeOvhHoOj/AA2/ad8JyeK9AtLSG1t9f0xki1O0hVQq+YrYjugAMZJR8dSxr9Tv2cv2rPgH+1p4Kbx3+z98RbLXrGBljvoY90dzYuwyEngcB4mIzjcMNg4Jr+XmK4VrWHB6R9a9K/ZQ/ax+LP7HHxq0v44fB7WHhvbNwmoafJKRbaraEjzLW4UfejYd+qNhlwVFepJcy0R46lyuzP6fN0cZO4ZzyQacJN+B0HavlX9mH/grv+xf+0xpmn7PiHF4R1i7hjMmi+Kp1tykzA5iSc/upcEEDDAnj5RnFfUMN5DdRLPbyrIjKChU5DL6gjqKxtLqjaMk9Ey5u44PT1pVkAHzVB5xC5BBx69BSmaJ9ozyBSslqUrNXJ/Ocj5T3pxcg4qKNuQFFTYUDL4/Ck7ydg5k1dbnhkIUYwcg96sIbdAXYjgc56V8rfDj9uDxFptgLXx9pENyqpxchvLcADuMEHtXmXx+/wCChWt+KY5NC8EeN7DRbUjbI1reIk2fQuWyD9Npr2sPkOaYiaShZd3scVbNsFQjeT17Lc+x/iV8fvhd8IrRr3xj4rhimVcpYQt5lxJ7CMc/icD3r5s8d/8ABS3xZrPiCPSvhj4TXT7KOX/SZ72QSTzR55wANsRx/v4r5I1X40eD9O1Hbq2sXHiHUnfdJY6UxuZW75dgcID6swq/pvxF8OfEK+t4bD4V3nhfT7fL6tcT6iJppowcnaNzgMeg6Ad819dl/CuX0bSry55dtbfcv1Z8/is+xdX+FHlX4nY/FL9rr/hbXxIg0qLwjdX0FjHIjate6o+I8nORuBEjA8ZVUGD17V5l4s8QG/v3i3urjPPrVq9u/CeseJNR8Q+CfDkumabPtjgs7i4810IUBjuyc5bmuZ1B5U1eSORuP4QfSvecadCnyxSUell/kePKc6sryd36nI/E+0TUNJmicMoaJgBtzk896+Y9N8O3eo6ubJoj+7mCsCO+cYr6y8cWzzaBIkbEADpXj2h+D4rbU4ZGwXudUaVj2wAuB+ZJ/Gvi+JKb5lO59JkcuZ8qR+s/7EvhqLwX4ZtvB8iIYo9FsvKCrgbRCoBxXp3j2xi0tzeWikRlf3kYHA968x/Zv8VWFxpHhqaEpHI+ki3kZT8zGPG3P/AT+leueMplvrb/AEc8lcMa4501y6H2uCmuXTSx5nqUVrqcJks5Vde+Tgg1578QfDomtWiurcPGRwr8flXea5pUllObi3LRgkk7D+tYms/2pd2bBl+0qq/dKgHFcE6evK0elGopHyR8YfhwsBlltId6sxJSYfMv0PevF9Q8Mx2sjA25HPO5eK+wfiHpWnagStxasrqCF3J0rwv4geGo4ror5akKeCK8mrBqWqNLJnlcGk2cPzNbAY9B1pZ9EjvRm1h+Y88iunfS7YORwB70GKO3h3RwrkDjNc1TmfxbEuEXoc7b+HtsRiuThc5KVaSxtok2Qrtq2XWZy8jZLGkmFvt+UFj344rjk3J3WwKCiyhIpAyeeKwdYl8mNmXkjse1bt3KwVmCDjtXMeIblXQnbtz1x3rGcHKS1G3oebfEm6kuAVeTj0964iGMqgx1PWuv8bxPNM0UYPLZ/CuVwA+VIwK9XCxjbQ8DGyd7mnGSljHn0pzM7BZN3bOKillKWkQHpUaTYO1q7ba3seWpO+m5p2Wp6hAgTTr54XVuCDxjv9RX0d+y9/wVJ/a5/Y9a2i8GfEV77QkIDeH9WJvLAjj5REx3QHGeYyvXnNfMQuFSVQuFz1PrUsqmPcTH8jdCOlVe3Qm7Uj9gPh3/AMHBnirx/ZLDafDXwfb37YU2t5cXMYJx/BIJiDk9iFNd3Z/8FofizaSbNZ+AHh7PbyNYuEB9CMo2RX4fWpit7lCRtQt8zDjHvxXvv7Pv7W/ir9mrxDa65p1h4Y8f6PbS5bwz470GLU7KQccNFcK2B6lCrehFdeFhg5ySrR+epjWni4xbpu/l/wAE/Vi0/wCC1fjouGm/Z10dh3K+JJV/QwGtS0/4LQ+JXcte/s3WGz/pl4vkGfztDXLfsk/8Fvf+CFfxB0630H9sP/glz4I+HmrlAt1qvh/wDZ6rpbNwC+I4VuIs9QojkwON5PX1D/goVp3/AAR5+J37KJ+OH/BO+98E3PiBNXsrF7HwTqRgNvAxd5Hm00lTGcKBvMSnkDNelHA5fOVoRk2+ulvm1J2PMeY4qjrV91fP/K34n5/fEXwX4/1Xw4vi/wAb+HL65spAxj060hkktIAMZMjAASsBySeFz0HWvGtei8GzOmnQeHNO8hiA8X2RME9uMV0/xi/aO8eWk02i6L4ruobLypIWtkuDs2N94bc45715r4bil14fbfOzt6qTzX3OLrUXP2cFdniUoTUeZs+hvCHwGGj+BG8T6Tqvh5bKK3haW0srvNwpkIAQoq4yO/PArZ8M/Bzxf4q0G907wF4bkv7nyg9wI3RBFGWC5LOygDNeffC2CZlUsnzAEKxbrx0rtPGWqatbeG5rO2upUiuAFuUSUqJAD3A617OFjD2HM0efWm1U9TDvvButfD2Kfw74gtfs95ZOwubfzVYo/plSQSPauLvL83d0zGTaS2c55Jrp7rzRpUUZlPEYAY9TxXD3bRnUDEU2vnK5NefiJKCTW3ZnTSjzblnXQZtLlhmHyleDXmthbBdajRZcrHJlBjpXpN0vn6e9vO+1hGfpXmN9ex6RrIbdk78EetfNZ3QVfC2SPZyis6OITvofob+yhr1zrHgyyttNgMtyArRRx9XI4YA/TJ/CvoFdYRrFRKQSy/xGvjj9iH4nXWhx2t/prr5to4aNJRnk85P519y+IvB1t8Sfg3bftIeA7If2Y2qHSfEcECYFjqQVWDlcnYkqsD2Af/fArwMNzVMOn1jo0fdRqxpVVF6J9TiphDduyYU5PSsrXdJt41Mz24DdMg8EetWYorqJtxQDB5XdyKb4lmkksdsJ6AEkdfpRKLk73OyMlc8l+IOjxyPJ6DpXhHxH8LSrK9xuYbyTgDrX0R4reCcOfKIboST/AJxXl/j3TY7iAhSQQpwQK8/FUuZHVFqHU8GuNNSAkXDbVPT5BVSWyWaJo0yfQkV0ni7TZI5kDL0bJrPa3ibJEhAx0xXkSjK9lojWTTWhzraUlrHsMYYnkHNVJ91spz8obnbW5f8AlKu2LJIPcVg63cpFkSAYHSuCtFKRUXpdmTqV1syvQmuW1syOjADitDWtbiE5/ecVj3k8+osLS0DF5TtQY5OaiMG1b/IzqSVjjvGETWWkXGrtj5z5Ef1PJ/SuEiT5se/OK7z45sulatb+CVYE6fCrXLA/emcAkH6DArhoUfzRtHWvWoUnGKufO4yqnPQs3hUwxqCcbc81CoIAb1HNWL6L5YwOu3v2qrh2wMjA963a1scPmhzOHIyucHrWzpmt3NjE0KrG8Tj5o5FBBrD34YKD35q5aSwpdpFcghCRuIHanZW0E72IriWQLsIGTzxVjSproMR5LkAfM4GQBTNZtra2uylnOZIyAUc9cVKni7VYtI/sWN1EJUq5CjLAnvQpPm3GuVxNLTbaC/v47R7qOJJGCtNKcKue5rZt7CfwnqMGqeGvFwjutpK3mmzsjJz0JGD+FcvYXBMAG047YFXkWSBcMjbT1yOM10U22YzaS1PVfEN14f8AE2hNqUGvNFqVtIfPtXHEoLAZX/P8q7n9nW5t9A1mDWL2ygvEgmV/Iul3I+DnBA6g15NqFhFZ6x5MpKOw3EEc89D9K9e+BfhbWvFWoW2geFNKmvr+QEx28IG5gBk4yQM4HrX2mAlUqYzmkfPYrljQtHQ908QfEK98Wwwyt4Z0TTxBPLMDo2lpbb9+OH29cYwPTmuj8O3vwcPhdtX+ItvqeoXYmCWumWUgjR0KnLyN1GGxgA/ge3Laz4N8T+AvK0PxZpjWl5NbpMbZiC8asPl3AZweDxXPLqxm1Eaar7jDl5FB5A+nbtX2zkowatufPNLnvJ3IvFE4uUJQCNc/Iqg4x/SuTmW1M5ExJf26VteIdUYuY4HDBx0rn78iJd8OCSME5614+I5ova53RaepZ1AIdOeFOH28Edq8t8ZW0KXxmeEBgD83fNek2N39ukaBjwI8ZH8TCuC+IVnJHfOLhCvyk4UZBNeXmEIzo8x2YJyU7WPUf2LfGAXX30Oef52wYwT1X/6xr9Mf2IvGk/wh8aX2l+Mo5dQ+HHj2xGmeP9HALbUwfJv4QPuzQOdwYcldwwSEI/Gv4b+N9Q+Gnjax8W2tuZ0tZ1ae13Y82PPzJntkZGe3Wv2T/Z+l06bw3oHiW2Jm0nxHo1vqWiXEqj97BNGHGe24ZwR2Ir5ujh4tt206n2GFxCqU1Tb16Hf/ABS/Zj1r4T+MH8KX9zb37NGJ7HULR90V/bOMxzrt4ww59jmvPPF3w41vRYmdrc4cZ4OcV7546+IfjDTPgl/wjlqYZxprKdDvbg8WSE5MDHr5ZbGB/DzjggDstK8HWXxM+H0F3rfh59O1FYtt7ZzLloZBwy54zyDzXTUwlqd0ehQrVILlmfnl480e4so3lETZz6cGvJfFBnkDhojyfu19qfHv4NLprzxafbJsB+8VOfpXzJ4v8DTx3jxyx45P3RyK8bE0Kjeh7FKSlG9zwrX9CacAmMkt3I6Vy19ok8D42kIT8pxX0NZ/DOe4Q4t5W3L951xWK3wU8SS6zM1zpyGw2L9nfcdzMTyCMcAcV58sLVdtBqtGD1Pny/srhdzyQbeOCB1rzvxxqzRs9sgw68HmvqL4l/C6ew0l1srPDqMABa+bvHXwy8TLcNd3FlIAW4YIcAe9eVi6fLKzRrGoprQ5DQdCtJmGpa7eja+Si9hjrk+vtXefBHwFpWu6pd/E/Vp9mgaGjssrw7Vd1G4n32jn8a6z4af8E2/2mfjx8HdT+OdoLHQvAvh2ZhqXiXV3kS3jgVd008YVD9o2D+BSCW+X1x1P7dn7S/7Cfg79nzwt+z7+xtqOtazbRwmLxhrmq6QbSSfywu1Yw53N5j73ZsDhQO5r1MDlNSpS9rJcsVrd6X9Dw8bmdKjP2ad2+x8O+LZb3xj4u1PxPdIVN/eyTADnAJOB+VU10kwY3DLdvpW0/wASPA82YV02eBR3wDioRqeh6uS2mXm4jorja1dksPRjH40/RniVKlaUrtNGHqqFW8sjoOKpBTt4HNaGqKzSkHOQ2M0kWnlyrYAyK5XBWfLuac2mpQEY43jnNSKS16FYkYBrRj0tDMDnIB71n3rFdWZU6huKUqfLC7GpKWiYyeGXcyk8A1b8P+Ede8TzPHo9kZBGV8xtwAXJwM5NWL++067sobeOyVLiM4lkUn94MDGe3rUen6hqOlrKlneyQrPgSCNiNwByBRGEZNdiXKy2JIrK40y9l066Ox4JCjqOzCug1fx7rWuaVHoN80JhjKkbYQGYqMAk/Suct5cytKdz5PzFjk5rotC8Fajr+kzatpdzbyPbI7z2rSBZAijOVB6120YtKxhOUr6Hrf7Q/jj/AISLUNH0250G0tRo9qLa2kt0IZ48k/Nng8k9PWtz4LeL9a8M6lFqXh7UJ7OZUIW5t5CjjIwQCORxxXHfHvw3rWgzpqWsaDe2gLbQ1zavGCeuPmArvP2RvhR44+NUksHhhbUR2rRm7lvJzGsYY4HOD3FfaUpzjmfK+p89UXPhE0eurrWr+IFj1bWdTnu52jCtNPKWbaOAMmtPxT+0HqmueFV+F9l4e02x0+CxhgaW1tts8ojfduZweSWySMdz6msjxR4fPgPUb3w1JqcVy9jK0L3FvnazLwcZ5xXH6PJJc3kl5Iu4SSEI/UHHXmvqqtSdNJX1Z4lOneTYzWhiZLqIFmAyQP61hXRnaRWjjIySX59a7HWJNNtrMvOY4zjO+RwP5157f/EnwTFctBP4mtAwBOBMDivLr8sdJNI7qalLZXNbQrOVbxkeQrt4VcfrWf8AETSJL2MTphRj06ms5fjV8OdNkdr/AMTRsxHAi+Yn8q5bxx+1N4OVBaabps9xgYDt8oH+NcNbE4GnRanNL5nXDD4qVRckWQxaBNPqPlKxzu6V+13/AATH8Dah8dP+CXXhiXw9E99r/wAOr+/0q/sbePfMka3DzwgAc8280WPXae9fhVaftD6G159qOlSI3UY5zX0X+xT/AMFmfir+wj44f4h/BeAtc3Nr5Gp6RfMWsdSjGdizxggkqSSrgh1ycEBiD41HFYGEZctRXffZ/gejKnjYyjJRd0ftb4P/ALK8T+F30XUAssNzCUlVu4PByPWtab416n8PNU07w34nmkvmvAYzebB5k6r/ABt/ecLjcep618+/B3/grh+yN+098DY/2i/jFp958KvHFowi8Q6Ro2mzX+k6iTzHLEV5iZwDlWIZSrZ3jDV2mp/G79nX4waBaeJPC3xP0bVba3kWW21SzvARbuVBAfvGSCAQ3qRXVGjP2fMk7M9ulmNCtpJWkuh6f8U4dD8R2AuonjdZEJV8cV82eOPhnCdQaeKwDqXwW28V6ZL8TLTxbqF1ouhSxSjTbaP7f9mbKxkr94Hpg4zx70kMEWoIkInJGMnvXlV4OE7M9zDTcldHAeHfhXZT2qt9l2jHTGcmuptvhNpEloVk09CNpwCnQ12OiWljaqIY0znoQtbMNqomELAkHA2AVpTpRcL2HVm07I+b/H/7PLazMRBZhU6vJGvSvlH9szxh8L/2atLFt4kMc97dA/Z9NjYGV8fxY7D3r6o/4KSf8FK/hz+xB4IPhHRLO11f4garBnS9G3Bksojx9puccqv91Orn2BNfhl8Y/jR47+M/jG98ffEPxDPqWpX0zSSzytwuTnaqjhVHYDpXJi1h6MLvV9jz6uKqJclPc+l/jv8A8FYfj1+0H8Nm+A/jDXbLTfBEOhGy0Lwpotktva6f5ShoCuPmZ90a7mYktuOeuK+ONQ1S81ObbKcRjoo6VBJPNMN7HPbrSqhMe/Oa8XFY6ti7Key2RzUcLDDtyerfUSS3dV3BhgdqdpV39jvo51baAcN9KryOWOKtafaQ3NwkUsgRWOCx7VxHZa0bM6eZYtSlE0Dgr2ANaVjo0s6byNqj+KuT1S0udAvRBaX+9WTcjxk4qB9b1p+H1KXjtvNdFGtClq1c4qmHlPY7X7EIbpixwApIHrXKXG651uQpgfNxg1Re/u3w7Xb7gMZ3GrGgwzy6iGyzEjJPWtKleNZqNupMaEqUXJsuS2zR3YUbvritnwz4di8T69Bo11q0VikisTcTj5FwCRnkemKab6CyjltZ7JJHnUCOU9UOc8VHJbgfvHPI6V0RppNvsckpt2NHxv4HuPAuoQ2R1q1vBcW6zJNZvuQ57fWs0XU9sDJbTlT0yGwcelMlYOu8HvXQ/Dfw74H8RaheReN9elsIo7NmtZI2A3S5GAQVOeCeOOnWtkubSH5karW5/9k=\",\"gender\":[{\"value\":\"MLE\",\"language\":\"eng\"}],\"city\":[{\"value\":\"TEST_CITYeng\",\"language\":\"eng\"}],\"phone\":\"2261640506\",\"fullName\":[{\"value\":\"TEST_FULLNAMEeng\",\"language\":\"eng\"}],\"addressLine1\":[{\"value\":\"TEST_ADDRESSLINE1eng\",\"language\":\"eng\"}],\"dateOfBirth\":\"1992/04/15\",\"id\":\"did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IkRKWTJrdWpwUU9YUDR5R0h1Z01oMXFNZTd2VEFPZnR6THBhT29hbUFSOEkiLCJuIjoieEJCMU9LeUpmNDRoUkNrY1NJbTNiS1NManhJYlNOQThhRHB3dGpfV0owTXRGMWtJb1VYOGRKX3p3bHh3ZFBHS3A5R3BHa25hTUJFRVpLMnZwRjF4a1lFWHBzaEtSb2ZfVXlXT183NDBPS2xSaW5ycDRlOVlBY2lCQjF5QzhyTWprMzdPaER2OVJCQjBCNklFMTNkSXZQZktaWTZyZTFNTlE4RTliUURhTjVTbGxDdi1TUUxiNDlsTUZMdG5BZE96eW51bWg2SVNRakl0a1NMemdFTFczR210TmcyMTRhdjhSd09rSVBRaDh5WmhLaVp0ZlRkUUNQS0lHQjlCVHJYMzZVaS1VcHlLSDdGT0N4bWVGWVR0Rm1Pal91YVN0T3pselJyZVhob2loXzAwVTIzQjZ2c21CSVZIbFhRTVlCQnV6VUJ2SzM1S0ttNzZwV2RyQWQ0bVl3In0=\",\"UIN\":\"2042351307\",\"email\":\"Mimoto_AddIdentity_withValidParameters_smoke_Pos@mosip.net\"},\"proof\":{\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"https://api.released.mosip.net/.well-known/ida-public-key.json\",\"type\":\"RsaSignature2018\",\"created\":\"2025-12-23T10:27:09Z\",\"jws\":\"eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJraWQiOiJmajV4SGNCbE9fYzZGZlJRdHJxNlJnbjhScS1VcUZwTF9oWGltVnMweVRFIiwiYWxnIjoiUFMyNTYifQ..pOYRZzrl3OGXWU-Aa5YKKMW0D3aAlBzPIfq0Pk3z0ZRDtVOEtRqlw4uGeb6wFlYYZPClnZgZ_bM1EbMikWSyUaMakFL86ahVtgfsXCfvwcxoUtiW_yVPvk0KtF98N4HX_Q8bahh57A1fMgqf6sw_lzbvFyhMtZ_SNFPpKaCVz5xY8lIQx8rJFK--GFyrT1_0PdckwtajTxoI12FiQhO94LEAfghMQuOrDrGBbzX7krMDBKCn0uxPlXt6doZwx6qFjzSRwtYZG7lyhLYHnWt5fPQJOYJ2l4LPsFkGBuWLcYWwagk27DIlYEwr7vSZefrCpKveGMibnyzGeG-PTLdQDg\"},\"id\":\"https://api.released.mosip.net/credentials/9dfc0387-4d3c-430a-b319-73b3ba37d026\",\"type\":[\"MOSIPVerifiableCredential\",\"VerifiableCredential\"],\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://api.released.mosip.net/.well-known/mosip-ida-context.json\",{\"sec\":\"https://w3id.org/security#\"}],\"issuer\":\"https://api.released.mosip.net/.well-known/ida-controller.json\"}],\"id\":\"urn:uuid:b978c646-8c07-4c1f-9598-f3e5f195d342\",\"holder\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\",\"proof\":{\"type\":\"JsonWebSignature2020\",\"created\":\"2025-12-23T16:02:51Z\",\"challenge\":\"oNjl1LmAXj6pqygwQnMBFQ==\",\"domain\":\"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\"jws\":\"eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..QsdZRqx7X8HcuDD8R55FCpeuGMVLiMZnmZYoKpZ_B1r5FH687Xy15XMwH56gl8-6sGrwU9pdQctdN0afx_dkAg\",\"proofPurpose\":\"authentication\",\"verificationMethod\":\"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6Ik1yeklpejhWbTMyWVlsWUJmQWJLcHlKWnRwX1p1NEl2WVpRSzBiejQ4aXciLCJ1c2UiOiJzaWcifQ#0\"}}]}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "state",
+                      "value": "{{5_1_reqId}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "error",
+                      "value": "Invalid_Request",
+                      "type": "text",
+                      "disabled": true
+                    },
+                    {
+                      "key": "error_description",
+                      "value": "User denied authorization to share credentials",
+                      "type": "text",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{base_url}}/v1/verify/v2/vp-submission/direct-post",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "verify",
+                    "v2",
+                    "vp-submission",
+                    "direct-post"
                   ]
                 }
               },
@@ -4345,8 +4543,8 @@
                       "var txnId = responseJson.transactionId;",
                       "var encodedTxnId = btoa(txnId);",
                       "",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('6_1_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('6_1_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -4366,7 +4564,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            }\n        ]\n    }\n}",
+                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            }\n        ]\n    }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -4431,7 +4629,7 @@
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
+                      "value": "{{6_1_reqId}}",
                       "type": "text"
                     }
                   ]
@@ -4467,8 +4665,8 @@
                       "var responseJson = pm.response.json();",
                       "var txnId = responseJson.transactionId;",
                       "var encodedTxnId = btoa(txnId);",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('6_2_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('6_2_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -4488,7 +4686,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"cred_a_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            },\n            {\n                \"id\": \"cred_b_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            }\n        ]\n    }\n}",
+                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"cred_a_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            },\n            {\n                \"id\": \"cred_b_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            }\n        ]\n    }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -4553,7 +4751,7 @@
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
+                      "value": "{{6_2_reqId}}",
                       "type": "text"
                     }
                   ]
@@ -4589,8 +4787,8 @@
                       "var responseJson = pm.response.json();",
                       "var txnId = responseJson.transactionId;",
                       "var encodedTxnId = btoa(txnId);",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('6_3_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('6_3_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -4610,7 +4808,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            }\n        ]\n    }\n}",
+                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            }\n        ]\n    }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -4675,7 +4873,7 @@
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
+                      "value": "{{6_3_reqId}}",
                       "type": "text"
                     }
                   ]
@@ -4711,8 +4909,8 @@
                       "var responseJson = pm.response.json();",
                       "var txnId = responseJson.transactionId;",
                       "var encodedTxnId = btoa(txnId);",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('6_4_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('6_4_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -4732,7 +4930,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            }\n        ]\n    }\n}",
+                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            }\n        ]\n    }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -4797,7 +4995,7 @@
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
+                      "value": "{{6_4_reqId}}",
                       "type": "text"
                     }
                   ]
@@ -4833,8 +5031,8 @@
                       "var responseJson = pm.response.json();",
                       "var txnId = responseJson.transactionId;",
                       "var encodedTxnId = btoa(txnId);",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('6_5_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('6_5_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -4854,7 +5052,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"dc+sd-jwt\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"vct_values\": [\n                        \"eu.europa.ec.eudi.pid.1\"\n                    ]\n                }\n            }\n        ]\n    }\n}",
+                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"dc+sd-jwt\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"vct_values\": [\n                        \"eu.europa.ec.eudi.pid.1\"\n                    ]\n                }\n            }\n        ]\n    }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -4919,7 +5117,7 @@
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
+                      "value": "{{6_5_reqId}}",
                       "type": "text"
                     }
                   ]
@@ -4955,8 +5153,8 @@
                       "var responseJson = pm.response.json();",
                       "var txnId = responseJson.transactionId;",
                       "var encodedTxnId = btoa(txnId);",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('6_6_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('6_6_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -4976,7 +5174,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                },\n                \"claims\": [\n                    {\n                        \"id\": \"name_claim\",\n                        \"path\": [\n                            \"fullName\"\n                        ]\n                    }\n                ]\n            }\n        ]\n    }\n}",
+                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                },\n                \"claims\": [\n                    {\n                        \"id\": \"name_claim\",\n                        \"path\": [\n                            \"fullName\"\n                        ]\n                    }\n                ]\n            }\n        ]\n    }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -5041,7 +5239,7 @@
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
+                      "value": "{{6_6_reqId}}",
                       "type": "text"
                     }
                   ]
@@ -5077,8 +5275,8 @@
                       "var responseJson = pm.response.json();",
                       "var txnId = responseJson.transactionId;",
                       "var encodedTxnId = btoa(txnId);",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('6_7_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('6_7_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -5098,7 +5296,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                },\n                \"claims\": [\n                    {\n                        \"id\": \"gender_claim\",\n                        \"path\": [\n                            \"gender\"\n                        ],\n                        \"values\": [\n                            \"Male\"\n                        ]\n                    }\n                ]\n            }\n        ]\n    }\n}",
+                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                },\n                \"claims\": [\n                    {\n                        \"id\": \"gender_claim\",\n                        \"path\": [\n                            \"gender\"\n                        ],\n                        \"values\": [\n                            \"Male\"\n                        ]\n                    }\n                ]\n            }\n        ]\n    }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -5163,7 +5361,7 @@
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
+                      "value": "{{6_7_reqId}}",
                       "type": "text"
                     }
                   ]
@@ -5199,8 +5397,8 @@
                       "var responseJson = pm.response.json();",
                       "var txnId = responseJson.transactionId;",
                       "var encodedTxnId = btoa(txnId);",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('6_8_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('6_8_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -5220,7 +5418,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                },\n                \"claims\": [\n                    {\n                        \"id\": \"claim_a\",\n                        \"path\": [\n                            \"fieldA\"\n                        ]\n                    },\n                    {\n                        \"id\": \"claim_b\",\n                        \"path\": [\n                            \"fieldB\"\n                        ]\n                    }\n                ],\n                \"claim_sets\": [\n                    [\n                        \"claim_a\",\n                        \"claim_b\"\n                    ]\n                ]\n            }\n        ]\n    }\n}",
+                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                },\n                \"claims\": [\n                    {\n                        \"id\": \"claim_a\",\n                        \"path\": [\n                            \"fieldA\"\n                        ]\n                    },\n                    {\n                        \"id\": \"claim_b\",\n                        \"path\": [\n                            \"fieldB\"\n                        ]\n                    }\n                ],\n                \"claim_sets\": [\n                    [\n                        \"claim_a\",\n                        \"claim_b\"\n                    ]\n                ]\n            }\n        ]\n    }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -5285,7 +5483,7 @@
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
+                      "value": "{{6_8_reqId}}",
                       "type": "text"
                     }
                   ]
@@ -5321,8 +5519,8 @@
                       "var responseJson = pm.response.json();",
                       "var txnId = responseJson.transactionId;",
                       "var encodedTxnId = btoa(txnId);",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('6_9_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('6_9_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -5342,7 +5540,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            }\n        ]\n    }\n}",
+                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"ldp_vc\",\n                \"require_cryptographic_holder_binding\": false,\n                \"meta\": {\n                    \"type_values\": [\n                        [\n                            \"MOSIPVerifiableCredential\"\n                        ]\n                    ]\n                }\n            }\n        ]\n    }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -5407,7 +5605,7 @@
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
+                      "value": "{{6_9_reqId}}",
                       "type": "text"
                     }
                   ]
@@ -5431,7 +5629,7 @@
           ]
         },
         {
-          "name": "6.11. vp submission - dcql query matching - sd-jwt missing cnf",
+          "name": "6.10. vp submission - dcql query matching - sd-jwt missing cnf",
           "item": [
             {
               "name": "vp request",
@@ -5443,8 +5641,8 @@
                       "var responseJson = pm.response.json();",
                       "var txnId = responseJson.transactionId;",
                       "var encodedTxnId = btoa(txnId);",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('6_10_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('6_10_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -5464,7 +5662,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"dc+sd-jwt\"\n            }\n        ]\n    }\n}",
+                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"dc+sd-jwt\",\n                \"meta\": {\n                    \"vct_values\": [\"eu.europa.ec.eudi.pid.1\"]\n                }\n            }\n        ]\n    }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -5529,7 +5727,7 @@
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
+                      "value": "{{6_10_reqId}}",
                       "type": "text"
                     }
                   ]
@@ -5553,7 +5751,7 @@
           ]
         },
         {
-          "name": "6.12. vp submission - dcql query matching - sd-jwt missing key binding",
+          "name": "6.11. vp submission - dcql query matching - sd-jwt missing key binding",
           "item": [
             {
               "name": "vp request",
@@ -5565,8 +5763,8 @@
                       "var responseJson = pm.response.json();",
                       "var txnId = responseJson.transactionId;",
                       "var encodedTxnId = btoa(txnId);",
-                      "pm.collectionVariables.set('txnIdForVPSession', encodedTxnId);",
-                      "pm.collectionVariables.set('reqIdForInvalidRequest', responseJson.requestId);",
+                      "pm.collectionVariables.set('6_11_txnId', encodedTxnId);",
+                      "pm.collectionVariables.set('6_11_reqId', responseJson.requestId);",
                       "",
                       "pm.test(\"Status code is 201\", function () {",
                       "    pm.response.to.have.status(201);",
@@ -5586,7 +5784,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"oNjl1LmAXj6pqygwQnMBFQ==\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"dc+sd-jwt\"\n            }\n        ]\n    }\n}",
+                  "raw": "{\n    \"clientId\": \"redirect_uri:https://faceb18cd424.ngrok-free.app/verifier/vp-response\",\n    \"nonce\": \"IvfM76kOqj8Xy5H9pFBGBQ\",\n    \"responseCodeValidationRequired\": true,\n    \"dcqlQuery\": {\n        \"credentials\": [\n            {\n                \"id\": \"id_credential_query\",\n                \"format\": \"dc+sd-jwt\",\n                \"meta\": {\n                    \"vct_values\": [\"eu.europa.ec.eudi.pid.1\"]\n                }\n            }\n        ]\n    }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -5651,7 +5849,7 @@
                     },
                     {
                       "key": "state",
-                      "value": "{{reqIdForInvalidRequest}}",
+                      "value": "{{6_11_reqId}}",
                       "type": "text"
                     }
                   ]
@@ -5690,7 +5888,7 @@
           "if (!currentUrl || currentUrl === \"\") {",
           "    const errorMessage = `",
           "    ",
-          "    \ud83d\udd34 CONFIGURATION REQUIRED \ud83d\udd34",
+          "    🔴 CONFIGURATION REQUIRED 🔴",
           "    ---------------------------------------------------",
           "    The 'base_url' variable is missing or empty.",
           "    ",
@@ -5794,6 +5992,238 @@
     },
     {
       "key": "reqId_with_response_code",
+      "value": ""
+    },
+    {
+      "key": "3_2_txnId",
+      "value": ""
+    },
+    {
+      "key": "3_2_reqId",
+      "value": ""
+    },
+    {
+      "key": "3_2_responseCode",
+      "value": ""
+    },
+    {
+      "key": "3_2_transactionId",
+      "value": ""
+    },
+    {
+      "key": "3_3_txnId",
+      "value": ""
+    },
+    {
+      "key": "3_3_reqId",
+      "value": ""
+    },
+    {
+      "key": "4_1_txnId",
+      "value": ""
+    },
+    {
+      "key": "4_1_reqId",
+      "value": ""
+    },
+    {
+      "key": "1_1_txnId",
+      "value": ""
+    },
+    {
+      "key": "1_1_reqId",
+      "value": ""
+    },
+    {
+      "key": "1_2_txnId",
+      "value": ""
+    },
+    {
+      "key": "1_2_reqId",
+      "value": ""
+    },
+    {
+      "key": "1_3_txnId",
+      "value": ""
+    },
+    {
+      "key": "1_3_reqId",
+      "value": ""
+    },
+    {
+      "key": "1_4_txnId",
+      "value": ""
+    },
+    {
+      "key": "1_4_reqId",
+      "value": ""
+    },
+    {
+      "key": "1_5_txnId",
+      "value": ""
+    },
+    {
+      "key": "1_5_reqId",
+      "value": ""
+    },
+    {
+      "key": "1_6_txnId",
+      "value": ""
+    },
+    {
+      "key": "1_6_reqId",
+      "value": ""
+    },
+    {
+      "key": "1_7_txnId",
+      "value": ""
+    },
+    {
+      "key": "1_7_reqId",
+      "value": ""
+    },
+    {
+      "key": "1_8_txnId",
+      "value": ""
+    },
+    {
+      "key": "1_8_reqId",
+      "value": ""
+    },
+    {
+      "key": "1_9_txnId",
+      "value": ""
+    },
+    {
+      "key": "1_9_reqId",
+      "value": ""
+    },
+    {
+      "key": "2_1_txnId",
+      "value": ""
+    },
+    {
+      "key": "2_1_reqId",
+      "value": ""
+    },
+    {
+      "key": "2_2_txnId",
+      "value": ""
+    },
+    {
+      "key": "2_2_reqId",
+      "value": ""
+    },
+    {
+      "key": "3_1_txnId",
+      "value": ""
+    },
+    {
+      "key": "3_1_reqId",
+      "value": ""
+    },
+    {
+      "key": "3_1_responseCode",
+      "value": ""
+    },
+    {
+      "key": "3_1_transactionId",
+      "value": ""
+    },
+    {
+      "key": "5_1_txnId",
+      "value": ""
+    },
+    {
+      "key": "5_1_reqId",
+      "value": ""
+    },
+    {
+      "key": "6_1_txnId",
+      "value": ""
+    },
+    {
+      "key": "6_1_reqId",
+      "value": ""
+    },
+    {
+      "key": "6_2_txnId",
+      "value": ""
+    },
+    {
+      "key": "6_2_reqId",
+      "value": ""
+    },
+    {
+      "key": "6_3_txnId",
+      "value": ""
+    },
+    {
+      "key": "6_3_reqId",
+      "value": ""
+    },
+    {
+      "key": "6_4_txnId",
+      "value": ""
+    },
+    {
+      "key": "6_4_reqId",
+      "value": ""
+    },
+    {
+      "key": "6_5_txnId",
+      "value": ""
+    },
+    {
+      "key": "6_5_reqId",
+      "value": ""
+    },
+    {
+      "key": "6_6_txnId",
+      "value": ""
+    },
+    {
+      "key": "6_6_reqId",
+      "value": ""
+    },
+    {
+      "key": "6_7_txnId",
+      "value": ""
+    },
+    {
+      "key": "6_7_reqId",
+      "value": ""
+    },
+    {
+      "key": "6_8_txnId",
+      "value": ""
+    },
+    {
+      "key": "6_8_reqId",
+      "value": ""
+    },
+    {
+      "key": "6_9_txnId",
+      "value": ""
+    },
+    {
+      "key": "6_9_reqId",
+      "value": ""
+    },
+    {
+      "key": "6_10_txnId",
+      "value": ""
+    },
+    {
+      "key": "6_10_reqId",
+      "value": ""
+    },
+    {
+      "key": "6_11_txnId",
+      "value": ""
+    },
+    {
+      "key": "6_11_reqId",
       "value": ""
     }
   ]

--- a/verify-service/src/main/java/io/inji/verify/dto/authorizationrequest/VPRequestCreateDto.java
+++ b/verify-service/src/main/java/io/inji/verify/dto/authorizationrequest/VPRequestCreateDto.java
@@ -18,7 +18,7 @@ public class VPRequestCreateDto {
     String clientId;
     @Schema(description = "Transaction identifier for the VP request.")
     String transactionId;
-    @Schema(description = "Nonce for the VP request.")
+    @Schema(description = "Optional nonce for the VP request. If omitted, a cryptographically random nonce is generated. When provided, must contain only ASCII URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~) and be at least 16 characters.")
     String nonce;
     @Valid
     @NotNull(message = "DCQL_QUERY_REQUIRED")

--- a/verify-service/src/main/java/io/inji/verify/enums/ErrorCode.java
+++ b/verify-service/src/main/java/io/inji/verify/enums/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     DCQL_CLAIM_PATH_INVALID("dcql_query.credentials","DCQL claim path must be a valid path."),
     DCQL_ALL_CREDENTIAL_SETS_OPTIONAL("dcql_query.credential_sets","credential_sets must contain at least one required entry."),
     CLIENT_ID_REQUIRED("invalid_request","client_id is required"),
+    NONCE_INVALID("invalid_request", "Nonce must contain only ASCII URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~) and be at least 16 characters."),
     DID_CREATION_FAILED("DID_CREATION_FAILED","Error while creating DID document."),
     VP_SUBMISSION_EXCEPTION("VP_SUBMISSION_EXCEPTION","Error while processing VP submission"),
     TOKEN_MATCHING_FAILED("TOKEN_MATCHING_FAILED", "Token matching failed."),

--- a/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationRequestServiceImpl.java
+++ b/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationRequestServiceImpl.java
@@ -22,6 +22,7 @@ import io.inji.verify.enums.ErrorCode;
 import io.inji.verify.enums.VPRequestStatus;
 import io.inji.verify.exception.JWTCreationException;
 import io.inji.verify.exception.VPRequestNotFoundException;
+import io.inji.verify.exception.VPRequestValidationException;
 import io.inji.verify.models.AuthorizationRequestCreateResponse;
 import io.inji.verify.models.VPSubmission;
 import io.inji.verify.repository.AuthorizationRequestCreateResponseRepository;
@@ -35,8 +36,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.async.DeferredResult;
 import java.text.ParseException;
+import java.util.regex.Pattern;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -67,6 +70,8 @@ public class VerifiablePresentationRequestServiceImpl implements VerifiablePrese
 
     ConcurrentHashMap<String, DeferredResult<VPRequestStatusDto>> vpRequestStatusListeners = new ConcurrentHashMap<>();
 
+    private static final Pattern NONCE_PATTERN = Pattern.compile("^[A-Za-z0-9\\-._~]{16,}$");
+
     public VerifiablePresentationRequestServiceImpl(
             AuthorizationRequestCreateResponseRepository authorizationRequestCreateResponseRepository,
             VPSubmissionRepository vpSubmissionRepository,
@@ -84,7 +89,15 @@ public class VerifiablePresentationRequestServiceImpl implements VerifiablePrese
         String transactionId = vpRequestCreate.getTransactionId() != null ? vpRequestCreate.getTransactionId() : Utils.generateID(Constants.TRANSACTION_ID_PREFIX);
         String requestId = Utils.generateID(Constants.REQUEST_ID_PREFIX);
         long expiresAt = Instant.now().plusSeconds(Constants.DEFAULT_EXPIRY).toEpochMilli();
-        String nonce = vpRequestCreate.getNonce() != null ? vpRequestCreate.getNonce() : SecurityUtils.generateNonce();
+        String nonce;
+        if (StringUtils.hasText(vpRequestCreate.getNonce())) {
+            if (!NONCE_PATTERN.matcher(vpRequestCreate.getNonce()).matches()) {
+                throw new VPRequestValidationException(ErrorCode.NONCE_INVALID);
+            }
+            nonce = vpRequestCreate.getNonce();
+        } else {
+            nonce = SecurityUtils.generateNonce();
+        }
         String responseUri = verifyServiceBaseUrl + Constants.VP_RESPONSE_SUBMISSION_URI;
 
         boolean responseCodeValidationRequired = vpRequestCreate.isResponseCodeValidationRequired();

--- a/verify-service/src/main/java/io/inji/verify/utils/SecurityUtils.java
+++ b/verify-service/src/main/java/io/inji/verify/utils/SecurityUtils.java
@@ -8,24 +8,16 @@ import java.security.KeyFactory;
 import java.security.SecureRandom;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
 
 public class SecurityUtils {
 
     private static final SecureRandom random = new SecureRandom();
 
-    public static String generateNonce()
-    {
+    public static String generateNonce() {
         byte[] randomBytes = new byte[16];
         random.nextBytes(randomBytes);
-        StringBuilder hexString = new StringBuilder();
-        for (byte b : randomBytes) {
-            String hex = Integer.toHexString(0xff & b);
-            if (hex.length() == 1) {
-                hexString.append('0');
-            }
-            hexString.append(hex);
-        }
-        return hexString.toString();
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
     }
 
     public static RSAPublicKey readX509PublicKey(String pem) throws Exception {

--- a/verify-service/src/test/java/io/inji/verify/services/impl/VerifiablePresentationRequestServiceImplTest.java
+++ b/verify-service/src/test/java/io/inji/verify/services/impl/VerifiablePresentationRequestServiceImplTest.java
@@ -9,7 +9,9 @@ import io.inji.verify.dto.authorizationrequest.VPRequestCreateDto;
 import io.inji.verify.dto.authorizationrequest.VPRequestResponseDto;
 import io.inji.verify.dto.authorizationrequest.VPRequestStatusDto;
 import io.inji.verify.dto.dcql.DCQLQueryDto;
+import io.inji.verify.enums.ErrorCode;
 import io.inji.verify.exception.VPRequestNotFoundException;
+import io.inji.verify.exception.VPRequestValidationException;
 import com.nimbusds.jwt.SignedJWT;
 import io.inji.verify.testsupport.DcqlTestFixtures;
 import io.inji.verify.enums.VPRequestStatus;
@@ -304,6 +306,67 @@ class VerifiablePresentationRequestServiceImplTest {
         assertNotNull(responseDto.getAuthorizationDetails());
         assertTrue(responseDto.getAuthorizationDetails().isResponseCodeValidationRequired());
         assertTrue(responseDto.getExpiresAt() > Instant.now().toEpochMilli());
+    }
+
+    @Test
+    void shouldUseProvidedNonce_whenValidNonceSupplied() throws Exception {
+        when(mockAuthorizationRequestCreateResponseRepository.save(any(AuthorizationRequestCreateResponse.class)))
+                .thenReturn(null);
+        String validNonce = "abcABC123-._~valid";  // 18 chars, all URL-safe
+
+        VPRequestCreateDto dto = new VPRequestCreateDto("client", "tx", validNonce, minimalDcqlQuery(), false);
+
+        VPRequestResponseDto response = service.createAuthorizationRequest(dto);
+
+        assertEquals(validNonce, response.getAuthorizationDetails().getNonce());
+    }
+
+    @Test
+    void shouldGenerateNonce_whenNonceIsNull() throws Exception {
+        when(mockAuthorizationRequestCreateResponseRepository.save(any(AuthorizationRequestCreateResponse.class)))
+                .thenReturn(null);
+
+        VPRequestCreateDto dto = new VPRequestCreateDto("client", "tx", null, minimalDcqlQuery(), false);
+
+        VPRequestResponseDto response = service.createAuthorizationRequest(dto);
+
+        assertNotNull(response.getAuthorizationDetails().getNonce());
+        assertFalse(response.getAuthorizationDetails().getNonce().isBlank());
+    }
+
+    @Test
+    void shouldGenerateNonce_whenNonceIsBlank() throws Exception {
+        when(mockAuthorizationRequestCreateResponseRepository.save(any(AuthorizationRequestCreateResponse.class)))
+                .thenReturn(null);
+
+        VPRequestCreateDto dto = new VPRequestCreateDto("client", "tx", "   ", minimalDcqlQuery(), false);
+
+        VPRequestResponseDto response = service.createAuthorizationRequest(dto);
+
+        // blank nonce must NOT be used — a generated nonce must replace it
+        assertNotNull(response.getAuthorizationDetails().getNonce());
+        assertFalse(response.getAuthorizationDetails().getNonce().isBlank());
+        assertNotEquals("   ", response.getAuthorizationDetails().getNonce());
+    }
+
+    @Test
+    void shouldFail_whenNonceContainsDisallowedCharacters() throws Exception {
+        VPRequestCreateDto dto = new VPRequestCreateDto("client", "tx", "invalid nonce value!", minimalDcqlQuery(), false);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> service.createAuthorizationRequest(dto));
+
+        assertEquals(ErrorCode.NONCE_INVALID, ex.getErrorCode());
+    }
+
+    @Test
+    void shouldFail_whenNonceIsTooShort() throws Exception {
+        VPRequestCreateDto dto = new VPRequestCreateDto("client", "tx", "short", minimalDcqlQuery(), false);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> service.createAuthorizationRequest(dto));
+
+        assertEquals(ErrorCode.NONCE_INVALID, ex.getErrorCode());
     }
 
     @Test

--- a/verify-service/src/test/java/io/inji/verify/utils/SecurityUtilsTest.java
+++ b/verify-service/src/test/java/io/inji/verify/utils/SecurityUtilsTest.java
@@ -15,9 +15,11 @@ class SecurityUtilsTest {
     void testGenerateNonce_LengthAndFormat() {
         String nonce = SecurityUtils.generateNonce();
 
-        assertEquals(32, nonce.length());
+        assertEquals(22, nonce.length());
 
-        assertTrue(Pattern.matches("^[0-9a-f]+$", nonce));
+        // Base64URL without padding: [A-Za-z0-9\-_], no '=' padding
+        assertTrue(Pattern.matches("^[A-Za-z0-9\\-_]+$", nonce));
+        assertFalse(nonce.contains("="), "Nonce must not contain Base64 padding");
 
         Set<String> nonces = new HashSet<>();
         for (int i = 0; i < 5; i++) {


### PR DESCRIPTION

- Blank nonce (e.g. "   ") bypassed the != null check and was stored as-is instead of triggering cryptographic generation. Fixed by using StringUtils.hasText().
- No format or length validation on caller-provided nonces. A single character or nonce with disallowed characters (spaces, =, #, etc.) was accepted silently. Fixed by validating against ^[A-Za-z0-9\-._~]{16,}$ per OpenID4VP spec.
- generateNonce() used a manual byte-to-hex loop producing 32-char output using only 16 of 66 allowed URL-safe characters. Replaced with Base64.getUrlEncoder().withoutPadding().encodeToString() — same 128-bit entropy in 22 chars using the full Base64URL charset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for nonce parameters in Verifiable Presentation requests with specific ASCII URL-safe format and minimum length requirements.
  * Automatic nonce generation when no nonce is provided in requests.
  * Enhanced error handling with dedicated error codes for invalid nonce values.

* **Tests**
  * Added comprehensive test coverage for nonce validation, auto-generation, and format verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->