### PR TITLE
#2043 added clientId nonce validation for sd-jwt, #1988 integration with validateKeyBindingJwt

### DIFF
--- a/docs/Inji_Verify_Postman_Collection.json
+++ b/docs/Inji_Verify_Postman_Collection.json
@@ -2656,7 +2656,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\r\n    \"clientId\": \"injiverify.dev-int-inji.mosip.net\",\r\n    \"nonce\": \"yMRlSK2ZT31GdWbedhk4hA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"vc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"eu.europa.ec.eudi.msisdn.1\"\r\n                    ]\r\n                },\r\n                \"require_cryptographic_holder_binding\": false,\r\n                \"claims\": [\r\n                    {\r\n                        \"id\": \"registered_family_name\",\r\n                        \"path\": [\r\n                            \"registered_family_name\"\r\n                        ],\r\n                        \"values\": [\"Musterman\"]\r\n                    },\r\n                    {\r\n                        \"id\": \"phone_number\",\r\n                        \"path\": [\r\n                            \"phone_number\"\r\n                        ]\r\n                    },\r\n                    {\r\n                        \"id\": \"verification_method_information\",\r\n                        \"path\": [\r\n                            \"verification_method_information\"\r\n                        ]\r\n                    }\r\n                ],\r\n                \"claim_sets\": [\r\n                    [\r\n                        \"phone_number\",\r\n                        \"verification_method_information\"\r\n                    ],\r\n                    [\r\n                        \"registered_family_name\"\r\n                    ]\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "raw": "{\r\n    \"clientId\": \"decentralized_identifier:did:web:injiverify.dev-int-inji.mosip.net:v1:verify\",\r\n    \"nonce\": \"5wMViKom3siY2zBBQ5trvA\",\r\n    \"responseCodeValidationRequired\": false,\r\n    \"dcqlQuery\": {\r\n        \"credentials\": [\r\n            {\r\n                \"id\": \"student_id_credential_query\",\r\n                \"format\": \"vc+sd-jwt\",\r\n                \"meta\": {\r\n                    \"vct_values\": [\r\n                        \"MockVerifiableCredential_SD_JWT\"\r\n                    ]\r\n                }\r\n            }\r\n        ]\r\n    }\r\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2706,7 +2706,7 @@
                   "urlencoded": [
                     {
                       "key": "vp_token",
-                      "value": "{\"student_id_credential_query\":[\"eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiIsIng1YyI6WyJNSUlCNVRDQ0FZdWdBd0lCQWdJUUdVZEYwa0JpUUdEYXdwKzBkQlNTNWpBS0JnZ3Foa2pPUFFRREFqQWRNUTR3REFZRFZRUURFd1ZCYm1sdGJ6RUxNQWtHQTFVRUJoTUNUa3d3SGhjTk1qVXdOREV5TVRReU16TXdXaGNOTWpZd05UQXlNVFF5TXpNd1dqQWhNUkl3RUFZRFZRUURFd2xqY21Wa2J5QmtZM014Q3pBSkJnTlZCQVlUQWs1TU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRUZYVk5BMGxhYSs1UDJuazVQSkZvdjh4aEJGTno1VU9KQklWc3lrMFNLU2ZxVGZLTUI2UitjRkROaWpkbUJZeXVFYVVnTWd1VWM4aE9Wbm5yZVc5dGhLT0JxRENCcFRBZEJnTlZIUTRFRmdRVVlSOHZGUVRsa2pmMS9ObktlWnh2WTBaejNhQXdEZ1lEVlIwUEFRSC9CQVFEQWdlQU1CVUdBMVVkSlFFQi93UUxNQWtHQnlpQmpGMEZBUUl3SHdZRFZSMGpCQmd3Rm9BVUw5OHdhTll2OVFueElIYjVDRmd4anZaVXRVc3dJUVlEVlIwU0JCb3dHSVlXYUhSMGNITTZMeTltZFc1clpTNWhibWx0Ynk1cFpEQVpCZ05WSFJFRUVqQVFnZzVtZFc1clpTNWhibWx0Ynk1cFpEQUtCZ2dxaGtqT1BRUURBZ05JQURCRkFpQkJ3ZFMvY0ZCczNhd3RmUDlHRlZrZ1NPSVRRZFBCTUxoc0pCeWpnN2wyTFFJaEFQUUpXeTdxUXNmcTJHcmRwY0dYSHJEVkswdy9YblBGMlhBVDZyVFg4dUNQIiwiTUlJQnp6Q0NBWFdnQXdJQkFnSVFWd0FGb2xXUWltOTRnbXlDaWMzYkNUQUtCZ2dxaGtqT1BRUURBakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d0hoY05NalF3TlRBeU1UUXlNek13V2hjTk1qZ3dOVEF5TVRReU16TXdXakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFRQy9ZeUJwY1JRWDhaWHBIZnJhMVROZFNiUzdxemdIWUhKM21zYklyOFRKTFBOWkk4VWw4ekpsRmRRVklWbHM1KzVDbENiTitKOUZVdmhQR3M0QXpBK280R1dNSUdUTUIwR0ExVWREZ1FXQkJRdjN6Qm8xaS8xQ2ZFZ2R2a0lXREdPOWxTMVN6QU9CZ05WSFE4QkFmOEVCQU1DQVFZd0lRWURWUjBTQkJvd0dJWVdhSFIwY0hNNkx5OW1kVzVyWlM1aGJtbHRieTVwWkRBU0JnTlZIUk1CQWY4RUNEQUdBUUgvQWdFQU1Dc0dBMVVkSHdRa01DSXdJS0Flb0J5R0dtaDBkSEJ6T2k4dlpuVnVhMlV1WVc1cGJXOHVhV1F2WTNKc01Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ1RnODBBbXFWSEpMYVp0MnV1aEF0UHFLSVhhZlAyZ2h0ZDlPQ21kRDUxWndJZ0t2VmtyZ1RZbHhTUkFibUtZNk1sa0g4bU0zU05jbkVKazlmR1Z3SkcrKzA9Il19.eyJjcmVkZW50aWFsX3R5cGUiOiJNU0lTRE4iLCJuYmYiOjE3NTI5ODQ3MzcsImV4cCI6MTc4NTM4NDczNywidmN0IjoiZXUuZXVyb3BhLmVjLmV1ZGkubXNpc2RuLjEiLCJjbmYiOnsia2lkIjoiZGlkOmp3azpleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TWpVMklpd2llQ0k2SWxKUk5XSkRiMngzUkZKV1pHUjRhbkk1TFUweUxVNUtPRVZ1TjFwSE1tTXpVbkZzVTJKVVR6TlJUMFVpTENKNUlqb2lZVlpFVVZkak5TMUJZbmhIYmxoV2JYRk1WMkphWmpGR1ZsWjFOVEF5TW0xaGFHdHpSVTh3VTJSZmR5SXNJblZ6WlNJNkluTnBaeUo5IzAifSwiaXNzIjoiaHR0cHM6Ly9mdW5rZS5hbmltby5pZCIsImlhdCI6MTc1Mzk0MjUyNywiX3NkIjpbIjI5SXE0b29UNzhGMkI1bFI1RzhGSGhGWWJKWmlER29vRHEySUpicFpCVG8iLCIzZVNTOEtZcUZzQVVHZVhIVWhwU21qd1k2TG5XaVJCMTVXYXRLY0ZTNzhJIiwiNE9mZGdDalZPUTJMbzhESXpTUEpodVVWT25yWGhjX1dkTGpCZDcwRGJFUSIsIkFwMWVweTdtVThiRkdrNXZkWXdlMjZma2pUY2taaW1uMDlncFlSR25XY3ciLCJEU0NWZHY3WklSOEZNNTR4c05MVlZqYndJc0JjcE9EUllHRTlCOTFra19RIiwiRnMwbGVHT0VMUU85ejhYblZsbVJTdXRUX0d3dDRTOWNubUJLcDF4TnRyQSIsIlFTbjl3dUx3LUJKY3VLRF9URHl0NGcyZlR4LU1KcmNyVzM0bVpKdHhtc0kiLCJfZDkyZVNKcW9FemdhQlctcFU2NUY2N3FOUno2Y2owRkJObDJYcTFmRWdFIiwia3VwOXhVUjZYMDZ5X3RiVVBPTzJ4VWxiWHJReG1qalRiVE9zMktYUUM4YyIsInBIYmh1eWxJbkZnaGtPY3hqcHVKb0o0S0hITUhfT2JSOWxYX0ZUa2Vmb2ciLCJ4YW1wZmJkRHJfd05LUllKN1F6NlAxZEZJcGJvMTJFdHRfZkMzYko4MDFvIl0sIl9zZF9hbGciOiJzaGEtMjU2In0.pf3MHMEAma64_-8mfmPdLCNzgzz5K0_EianTPd5IUzMlkXhB1v4NtQmRiARlLvTd9kkUChhW4lascAkW8TOnSA~WyI4NzY3MzA2NTE3OTE1MTMzMTI2NDI5MTUiLCJwaG9uZV9udW1iZXIiLCI0OTE1MTEyMzQ1NjciXQ~WyIyNzgzODk0ODU5Mjc2ODY0NTY1NjkxNzUiLCJyZWdpc3RlcmVkX2ZhbWlseV9uYW1lIiwiTXVzdGVybWFuIl0~WyI5Njk4OTYzODY5MDAwMTE3MzM0MTE0NDQiLCJyZWdpc3RlcmVkX2dpdmVuX25hbWUiLCJKb2huIE1pY2hhZWwiXQ~WyIxMDE3NzAzNzY5OTU2Mzc0MjI4NTIwMDQ4IiwiY29udHJhY3Rfb3duZXIiLHRydWVd~WyIxMTcwMTg2ODQ0MTkyNTczMzQyOTYyNDg5IiwiZW5kX3VzZXIiLGZhbHNlXQ~WyI0MzI1MjkxNDE2MzczOTU0MzgxNDM5NTUiLCJtb2JpbGVfb3BlcmF0b3IiLCJUZWxla29tX0RFIl0~WyI2ODA1NjkyNDQ3MTA1NjQ3ODc1ODQxNzUiLCJpc3N1aW5nX29yZ2FuaXphdGlvbiIsIlRlbE9yZyJd~WyI5MzE5ODU3NzkxNTk0Njc0ODE2NTg4ODciLCJ2ZXJpZmljYXRpb25fZGF0ZSIsIjIwMjMtMDgtMjUiXQ~WyI2MTkxMTk5NjI3Mzg2MDQ5MjI4ODkwMjEiLCJ2ZXJpZmljYXRpb25fbWV0aG9kX2luZm9ybWF0aW9uIiwiTnVtYmVyVmVyaWZ5Il0~WyIzNzM2NzUzNDQwNDA1ODI4Mzc2MTE0MjQiLCJpc3N1YW5jZV9kYXRlIiwiMjAyNS0wNy0yMFQwNDoxMjoxNy4wODlaIl0~WyI1NjU0NDMyNzk2MjEwMjQ2ODk0NjQ3MDgiLCJleHBpcnlfZGF0ZSIsIjIwMjYtMDctMzBUMDQ6MTI6MTcuMDg5WiJd~\"]}",
+                      "value": "{\"student_id_credential_query\":[\"eyJ4NXQjUzI1NiI6Ik5QMXpnRFRTUDJQbEFFck5hV1pJakV1MGVoeUowV3ZVVk94T3VSaVA4REkiLCJ4NWMiOlsiTUlJREVEQ0NBZmlnQXdJQkFnSUlwUXc4S2FaeUR6QXdEUVlKS29aSWh2Y05BUUVMQlFBd2VERUxNQWtHQTFVRUJoTUNTVTR4Q3pBSkJnTlZCQWdNQWt0Qk1SSXdFQVlEVlFRSERBbENRVTVIUVV4UFVrVXhEakFNQmdOVkJBb01CVWxKU1ZSQ01SY3dGUVlEVlFRTERBNUZXRUZOVUV4RkxVTkZUbFJGVWpFZk1CMEdBMVVFQXd3V2QzZDNMbVY0WVcxd2JHVXVZMjl0SUNoU1QwOVVLVEFlRncweU5UQTVNVFl3TmpVMU16WmFGdzB5T0RBNU1UVXdOalUxTXpaYU1JR2JNUXN3Q1FZRFZRUUdFd0pKVGpFTE1Ba0dBMVVFQ0F3Q1MwRXhFakFRQmdOVkJBY01DVUpCVGtkQlRFOVNSVEVPTUF3R0ExVUVDZ3dGU1VsSlZFSXhGekFWQmdOVkJBc01Ea1ZZUVUxUVRFVXRRMFZPVkVWU01VSXdRQVlEVlFRREREbDNkM2N1WlhoaGJYQnNaUzVqYjIwZ0tFTkZVbFJKUmxsZlZrTmZVMGxIVGw5RlExOVNNUzFGUTE5VFJVTlFNalUyVWpGZlUwbEhUaWt3V1RBVEJnY3Foa2pPUFFJQkJnZ3Foa2pPUFFNQkJ3TkNBQVRUUnBhRjhiNGFiUmY3YjFtdmtRNjUrZ1dtdkJ5VldZakVFcW0xWFlSSWMrYVFJaElVMFNzbllVaHUxR3pqY1Z0RlVVZDh2ZjBlR21QUnUxMENTc3BlbzBVd1F6QVNCZ05WSFJNQkFmOEVDREFHQVFIL0FnRUJNQjBHQTFVZERnUVdCQlRDUndTclZSaElTMnNVTVhWUDJGNTFRSE9PSnpBT0JnTlZIUThCQWY4RUJBTUNBb1F3RFFZSktvWklodmNOQVFFTEJRQURnZ0VCQUNKZHRYWTZKcldkRmhTMjI2bHBNM0pzd3p4RmtrSVhTN0xYY1lzLzlIc2xybEZqYjF6YWhOcEJWNzdJSHo3Y3h5UWFtNEhFQW43UEx2VGNXSWNIaU9PRzNObURCS2hHeTBmMGJQWjdsVFJPd0srOEgweHdIbHNwYkhuVlJaWkNBdnhGbFFWbkVWbWJmU0tUTGdscVBvM0FVUmRyeTdJa2k5dXdCSTU2OHpZRmEyWnZ4YWJnMkdHSG8zU2pWTlNFbG12RlBCc1VLNzljK3dOSStDRVdZR2pOUGNBNzV6emF3Qkw1N1ZKM3U5VEdOT3h2UzVHdmd6S0g3UmZiTkdvNGdUVWVoWWtkZ1JiUzhWRTRvMUtxWnNYSzdPYklVOVB5Z3pxTms0R1E5eGFUcURxU2I0TlRHREVxaENLQk5rZCs0TzNLZlJycjhVVjU5Vm5jSEhTQ0ZPYz0iLCJNSUlEdHpDQ0FwK2dBd0lCQWdJSUlWU0drNXlSM1Qwd0RRWUpLb1pJaHZjTkFRRUxCUUF3ZURFTE1Ba0dBMVVFQmhNQ1NVNHhDekFKQmdOVkJBZ01Ba3RCTVJJd0VBWURWUVFIREFsQ1FVNUhRVXhQVWtVeERqQU1CZ05WQkFvTUJVbEpTVlJDTVJjd0ZRWURWUVFMREE1RldFRk5VRXhGTFVORlRsUkZVakVmTUIwR0ExVUVBd3dXZDNkM0xtVjRZVzF3YkdVdVkyOXRJQ2hTVDA5VUtUQWVGdzB5TkRBM01qSXdOak14TWpKYUZ3MHpNakEzTWpBd05qTXhNakphTUhneEN6QUpCZ05WQkFZVEFrbE9NUXN3Q1FZRFZRUUlEQUpMUVRFU01CQUdBMVVFQnd3SlFrRk9SMEZNVDFKRk1RNHdEQVlEVlFRS0RBVkpTVWxVUWpFWE1CVUdBMVVFQ3d3T1JWaEJUVkJNUlMxRFJVNVVSVkl4SHpBZEJnTlZCQU1NRm5kM2R5NWxlR0Z0Y0d4bExtTnZiU0FvVWs5UFZDa3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDNmUvWFY5cXJPOVVQR1RWc2VIKzZjZ3dRWC9PalpKN3lZSTcyMG12NDlyT0R4dEdIWVR2NGRtaU1HQ3pPbTgzVUhpQnF3aE1Da0RZMnhTSkFHREt1NDlJZTBsbnFxNmJHdnh6RnhmdlQ1UVRER3NMWkhVZGc1dzFSZWpTaytjMUszNnB5cWxURkZWT2hVMWo5bmRkQTZxamRwY2oxRVpKWWZkNUFBc3BwQ1hQN0dxSGhuSGxlcU9nQk93d0pqeFBlellCZGN5aTM4MzZJM3d0cUFiaUMvbXJLTzF5aWNCdWNiMEN4ZS9NZEJ3MU1sa1REcnJZNnh3L3VDOUVDM0wzS3p6OCtMVFJoQWJOUEVTd1VmSWM2TFJ2cU9qTENnOTA3Mis1aGMxQzZOUG9JdTZWKzJZR1ptY3N4KzJNdkUrWHNLM0tEUVIvN25tL1JJR3d2WGtacFhBZ01CQUFHalJUQkRNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUl3SFFZRFZSME9CQllFRkEvb2MyNjZOQ05nSitYMXhXQnBKelZrWUJJQk1BNEdBMVVkRHdFQi93UUVBd0lDaERBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUdCczFvTWRpajBYaXZDV0NJZ3FIbCtJOG0yZDhlNVdmY3J5UjhWZERQNDF6Q0RPNXo4c3luZExtTXhyamEwMGhqb21TSVZzWXNpZndoOHhLN2FTa0o1NXVZaVpubjJ3K3oyQlU3WkJGRE9yMjRUREw4bzhLRW1BS3lFdXpHUnZqamlUNlY3ell1bFhTcHZaSjVlVjRuWDlIRzQzRWRlK2RsRDg0LzgwTnlDRnJwd1UzbEZWYmluNG0wU2V3RUxsREJadXYwYnhMNmlVUHBOeXI2TzRkMXRMMGxyYUNQc0pyeHh1OTNTbkJRQWpWc0M0VW1lcU1PMW8wVkNybXl4Y3dLTjZuN09JbGEwMGhzY212RDNodHlPaU11WnNXbFJ4TVVWMDVMdE93T05tQ09QUHVHeXdaZmJHS1hkZEN6Yml6YkVIOUt2Rmd3NENkZXRtZDlwamxZdz09Il0sImtpZCI6Imh0dHBzOi8vaW5qaWNlcnRpZnktbW9jay5yZWxlYXNlZC5tb3NpcC5uZXQjMU9oLXlwcThWV1JpTHc1dk05WnpsblJuVThjSTUwUDhSYXozRTE3OVUyMCIsInR5cCI6InZjK3NkLWp3dCIsImFsZyI6IkVTMjU2In0.eyJnZW5kZXIiOlt7Imxhbmd1YWdlIjoiZW5nIiwidmFsdWUiOiJmZW1hbGUifSx7Imxhbmd1YWdlIjoiZnJhIiwidmFsdWUiOiJmZU3DomxlIn0seyJsYW5ndWFnZSI6ImFyYSIsInZhbHVlIjoi2LDZg9ixIn1dLCJ2Y3QiOiJNb2NrVmVyaWZpYWJsZUNyZWRlbnRpYWxfU0RfSldUIiwicG9zdGFsQ29kZSI6NDUwMDksImlzcyI6Imh0dHBzOi8vaW5qaWNlcnRpZnktbW9jay5yZWxlYXNlZC5tb3NpcC5uZXQiLCJmdWxsTmFtZSI6W3sibGFuZ3VhZ2UiOiJmcmEiLCJ2YWx1ZSI6IkFsaGVyaSBCb2JieSJ9LHsibGFuZ3VhZ2UiOiJhcmEiLCJ2YWx1ZSI6Itiq2Krar9mE2K_Zg9mG2LPZjtiy2YLZh9mQ2YLZkNmB2YQg2K_Ys9mK2YrYs9mK2YPYr9mD2YbZiNqk2YgifSx7Imxhbmd1YWdlIjoiZW5nIiwidmFsdWUiOiJBbGhlcmkgQm9iYnkifV0sImRhdGVPZkJpcnRoIjoiMTk5OS8xMC8yMSIsIlZJRCI6MTIzMTIzMTIzMSwicHJvdmluY2UiOlt7Imxhbmd1YWdlIjoiZnJhIiwidmFsdWUiOiJ5dcSBbiAyIn0seyJsYW5ndWFnZSI6ImFyYSIsInZhbHVlIjoi2YrZjtmP2KfZhuqJm-KljSJ9LHsibGFuZ3VhZ2UiOiJlbmciLCJ2YWx1ZSI6Inl1YW4gd2VlIn1dLCJpc3N1YW5jZURhdGUiOiIyMDI2LTA2LTAzVDA1OjU0OjA1LjE3NVoiLCJwaG9uZSI6Iis5MTk0MjczNTc5MzQiLCJjbmYiOnsia2lkIjoiZGlkOmp3azpleUpyZEhraU9pSlBTMUFpTENKMWMyVWlPaUp6YVdjaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbTlKVUcxQlVqWkliMFpxY1dSTFZGbHRXRTVyVm14VGVXOU1ObHBpTVZNMWJ6QkNlaTFEVFhodlVWa2lmUT09In0sIlVJTiI6MTIzMTIzMTIzMSwiaWQiOiJodHRwczovL21vc2lwLmlvL2NyZWRlbnRpYWwvN2I3NzU5MjItNDI3NC00Njc1LThhMGQtMzIyODE4N2Y3NzNjIiwicmVnaW9uIjpbeyJsYW5ndWFnZSI6ImZyYSIsInZhbHVlIjoieXXEgW4gMyJ9LHsibGFuZ3VhZ2UiOiJhcmEiLCJ2YWx1ZSI6IiTZhNmP2Ybar--Al-GGkSJ9LHsibGFuZ3VhZ2UiOiJlbmciLCJ2YWx1ZSI6Inl1YW4gd2VlIDMifV0sImVtYWlsIjoic2l3ZXJrbUBnbWFpbC5jb20iLCJleHBpcmF0aW9uRGF0ZSI6IjIwMjgtMDYtMDJUMDU6NTQ6MDUuMTc1WiJ9.HgGWmexFM9ezqxUs7BkiIuZbGBTvuPK2qjfzWxkTPxH5sgxFk-KXUYZkRUILWJESbj8Z9wkBfuZ9wLVMBGYEMQ~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE3ODE2OTgwMTUsIm5vbmNlIjoiNXdNVmlLb20zc2lZMnpCQlE1dHJ2QSIsInNkX2hhc2giOiIzVU1tTkcyRUFLdnpfOTNsOFRrMER2aWdSQkVfX1dBQ21SYU9yRU9uTVBZIiwiYXVkIjoiZGVjZW50cmFsaXplZF9pZGVudGlmaWVyOmRpZDp3ZWI6aW5qaXZlcmlmeS5kZXYtaW50LWluamkubW9zaXAubmV0OnYxOnZlcmlmeSJ9.NXzSwmXcHI2JuIHZOYwbDqjylPc8vc6lfSiE8t3QKWjqOGvOhJujp_j_F-kSwyxMCpsSl1pzWrV-SKFY_OlDBg\"]}",
                       "type": "text"
                     },
                     {
@@ -3945,18 +3945,6 @@
                       "key": "state",
                       "value": "{{3_3_reqId}}",
                       "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
                     }
                   ]
                 },
@@ -4047,7 +4035,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
+                  "raw": "{\n  \"skipStatusChecks\": true,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -4159,18 +4147,6 @@
                       "key": "state",
                       "value": "{{4_1_reqId}}",
                       "type": "text"
-                    },
-                    {
-                      "key": "error",
-                      "value": "Invalid_Request",
-                      "type": "text",
-                      "disabled": true
-                    },
-                    {
-                      "key": "error_description",
-                      "value": "User denied authorization to share credentials",
-                      "type": "text",
-                      "disabled": true
                     }
                   ]
                 },
@@ -4254,7 +4230,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"skipStatusChecks\": false,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
+                  "raw": "{\n  \"skipStatusChecks\": true,\n  \"statusCheckFilters\": [\"revocation\", \"suspension\"],\n  \"includeClaims\": true\n}",
                   "options": {
                     "raw": {
                       "language": "json"

--- a/verify-service/src/main/java/io/inji/verify/controller/VCVerificationController.java
+++ b/verify-service/src/main/java/io/inji/verify/controller/VCVerificationController.java
@@ -26,6 +26,7 @@ public class VCVerificationController {
 
     @PostMapping(path = "/v2/vc-verification", consumes = MediaType.APPLICATION_JSON_VALUE)
     public VCVerificationResultDto verifyV2(@Valid @RequestBody VCVerificationRequestDto request) {
-        return VCVerificationService.verifyV2(request);
+        // Plain VC verification endpoint — no VP session context, KB-JWT validation not applicable.
+        return VCVerificationService.verifyV2(request, false);
     }
 }

--- a/verify-service/src/main/java/io/inji/verify/controller/VPResultController.java
+++ b/verify-service/src/main/java/io/inji/verify/controller/VPResultController.java
@@ -210,7 +210,10 @@ public class VPResultController {
 
     @ExceptionHandler(VPVerificationException.class)
     public ResponseEntity<ErrorDto> handleVPVerificationException(VPVerificationException e) {
-        String rootCause = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+        String causeMessage = e.getCause() != null ? e.getCause().getMessage() : null;
+        String rootCause = causeMessage != null ? causeMessage
+                : e.getMessage() != null ? e.getMessage()
+                : e.getClass().getName();
         log.warn("VP verification failed: {}", rootCause);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorDto(ErrorCode.VP_VERIFICATION_FAILED.getErrorCode(), rootCause));

--- a/verify-service/src/main/java/io/inji/verify/controller/VPResultController.java
+++ b/verify-service/src/main/java/io/inji/verify/controller/VPResultController.java
@@ -210,7 +210,9 @@ public class VPResultController {
 
     @ExceptionHandler(VPVerificationException.class)
     public ResponseEntity<ErrorDto> handleVPVerificationException(VPVerificationException e) {
-        log.warn("VP verification failed: {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorDto(ErrorCode.VP_VERIFICATION_FAILED));
+        String rootCause = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+        log.warn("VP verification failed: {}", rootCause);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorDto(ErrorCode.VP_VERIFICATION_FAILED.getErrorCode(), rootCause));
     }
 }

--- a/verify-service/src/main/java/io/inji/verify/controller/VPSubmissionController.java
+++ b/verify-service/src/main/java/io/inji/verify/controller/VPSubmissionController.java
@@ -37,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.sql.Timestamp;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -159,14 +160,12 @@ public class VPSubmissionController {
             }
         }
 
-        // ---- 7. Validate client_id and none if Verifiable Presentation is present
-        if (dcqlTokensDto != null && dcqlTokensDto.getLdpVpTokens() != null && !dcqlTokensDto.getLdpVpTokens().isEmpty()) {
-            ResponseEntity<?> clientIdNonceValidation = validateClientIdNonce(dcqlTokensDto.getLdpVpTokens(), authRequestCreateResponse);
+        // ---- 7. Validate client_id and nonce for all token types.
+        if (dcqlTokensDto != null) {
+            ResponseEntity<?> clientIdNonceValidation = validateClientIdNonce(dcqlTokensDto, authRequestCreateResponse);
             if (clientIdNonceValidation != null) {
                 return clientIdNonceValidation;
             }
-        } else {
-            log.debug("Skipping client_id and nonce validation as no LdpVpTokens extracted for state {}", state);
         }
         // ---- 8. generate response_code and build redirect_uri as required
         Map<String, Object> response = new HashMap<>();
@@ -198,20 +197,29 @@ public class VPSubmissionController {
 
     }
 
-    private ResponseEntity<?> validateClientIdNonce(Map<String, List<JSONObject>> ldpVpTokens, AuthorizationRequestCreateResponse authRequest) {
-        boolean isClientIdValid = verifiablePresentationSubmissionService
-                .isClientIdValid(authRequest.getAuthorizationDetails(), ldpVpTokens);
-        if (!isClientIdValid) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(new ErrorDto(ErrorCode.CLIENT_ID_VALIDATION_FAILED));
+    private ResponseEntity<?> validateClientIdNonce(DcqlTokensDto dcqlTokensDto, AuthorizationRequestCreateResponse authRequest) {
+        Map<String, List<JSONObject>> ldpVpTokens = dcqlTokensDto.getLdpVpTokens() != null ? dcqlTokensDto.getLdpVpTokens() : Collections.emptyMap();
+        Map<String, List<String>> sdJwtTokens = dcqlTokensDto.getSdJwtTokens() != null ? dcqlTokensDto.getSdJwtTokens() : Collections.emptyMap();
+        if (!ldpVpTokens.isEmpty()) {
+            ErrorCode error = verifiablePresentationSubmissionService
+                    .processLdpVpClientIdAndNonce(authRequest.getAuthorizationDetails(), ldpVpTokens);
+            if (error != null) {
+                log.error("LDP VP clientId/nonce validation failed: {}", error);
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorDto(error));
+            }
         }
-        boolean isNonceValid = verifiablePresentationSubmissionService
-                .isNonceValid(authRequest.getAuthorizationDetails(), ldpVpTokens);
-        if (!isNonceValid) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorDto(ErrorCode.NONCE_VALIDATION_FAILED));
+        if (!sdJwtTokens.isEmpty()) {
+            ErrorCode error = verifiablePresentationSubmissionService
+                    .processSdJwtClientIdAndNonce(authRequest.getAuthorizationDetails(), sdJwtTokens);
+            if (error != null) {
+                log.error("SD-JWT KB-JWT clientId/nonce validation failed: {}", error);
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorDto(error));
+            }
         }
-        return null; // Return null if both client_id and nonce are valid, indicating the request can
-        // proceed to the next validation steps
+        if (ldpVpTokens.isEmpty() && sdJwtTokens.isEmpty()) {
+            log.debug("Skipping clientId/nonce validation as no bindable tokens extracted.");
+        }
+        return null;
     }
 
     /**

--- a/verify-service/src/main/java/io/inji/verify/exception/VPVerificationException.java
+++ b/verify-service/src/main/java/io/inji/verify/exception/VPVerificationException.java
@@ -8,4 +8,8 @@ public class VPVerificationException extends RuntimeException {
     public VPVerificationException() {
         super(message);
     }
+
+    public VPVerificationException(Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/verify-service/src/main/java/io/inji/verify/services/VCVerificationService.java
+++ b/verify-service/src/main/java/io/inji/verify/services/VCVerificationService.java
@@ -9,5 +9,5 @@ public interface VCVerificationService {
 
     VCVerificationStatusDto verify(String vc, String contentType) throws CredentialStatusCheckException;
 
-    VCVerificationResultDto verifyV2(VCVerificationRequestDto request);
+    VCVerificationResultDto verifyV2(VCVerificationRequestDto request, boolean validateKeyBindingJwt);
 }

--- a/verify-service/src/main/java/io/inji/verify/services/VerifiablePresentationSubmissionService.java
+++ b/verify-service/src/main/java/io/inji/verify/services/VerifiablePresentationSubmissionService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.inji.verify.dto.result.DcqlTokensDto;
+import io.inji.verify.enums.ErrorCode;
 import org.json.JSONObject;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,9 +30,9 @@ public interface VerifiablePresentationSubmissionService {
 
     DcqlTokensDto extractDcqlTokens(String vpTokenString, AuthorizationRequestResponseDto authRequest) throws InvalidVpTokenException;
 
-    boolean isClientIdValid(AuthorizationRequestResponseDto authRequest, Map<String, List<JSONObject>> ldpVpTokens);
-    
-    boolean isNonceValid(AuthorizationRequestResponseDto authRequest, Map<String, List<JSONObject>> ldpVpTokens);
+    ErrorCode processLdpVpClientIdAndNonce(AuthorizationRequestResponseDto authRequest, Map<String, List<JSONObject>> ldpVpTokens);
+
+    ErrorCode processSdJwtClientIdAndNonce(AuthorizationRequestResponseDto authRequest, Map<String, List<String>> sdJwtTokens);
     
     String generateResponseCode(AuthorizationRequestResponseDto authRequest);
     

--- a/verify-service/src/main/java/io/inji/verify/services/impl/VCSubmissionServiceImpl.java
+++ b/verify-service/src/main/java/io/inji/verify/services/impl/VCSubmissionServiceImpl.java
@@ -47,7 +47,8 @@ public class VCSubmissionServiceImpl implements VCSubmissionService {
             CredentialFormat credentialFormat = Utils.getCredentialFormat(vc);
             List<String> statusPurposeList = new ArrayList<>();
             statusPurposeList.add(Constants.STATUS_PURPOSE_REVOKED);
-            CredentialVerificationSummary credentialVerificationSummary = credentialsVerifier.verifyAndGetCredentialStatus(vc, credentialFormat, statusPurposeList);
+            // Plain VC flow — no VP session context, KB-JWT validation not applicable.
+            CredentialVerificationSummary credentialVerificationSummary = credentialsVerifier.verifyAndGetCredentialStatus(vc, credentialFormat, statusPurposeList, false);
             VerificationStatus vcVerificationStatus = Utils.getVcVerificationStatus(credentialVerificationSummary);
 
             return new VCSubmissionVerificationStatusDto(vc, vcVerificationStatus);

--- a/verify-service/src/main/java/io/inji/verify/services/impl/VCVerificationServiceImpl.java
+++ b/verify-service/src/main/java/io/inji/verify/services/impl/VCVerificationServiceImpl.java
@@ -58,15 +58,16 @@ public class VCVerificationServiceImpl implements VCVerificationService {
 
         List<String> statusPurposeList = new ArrayList<>();
         statusPurposeList.add(Constants.STATUS_PURPOSE_REVOKED);
+        // Plain VC verification endpoint — no VP session context, KB-JWT validation not applicable.
         CredentialVerificationSummary credentialVerificationSummary =
-                credentialsVerifier.verifyAndGetCredentialStatus(vc, format, statusPurposeList);
+                credentialsVerifier.verifyAndGetCredentialStatus(vc, format, statusPurposeList, false);
         log.debug("CredentialVerificationResult: {}", credentialVerificationSummary.getVerificationResult());
         return new VCVerificationStatusDto(Utils.getVcVerificationStatus(credentialVerificationSummary));
     }
 
     @Override
-    public VCVerificationResultDto verifyV2(VCVerificationRequestDto request) {
-        log.debug("Processing verification request with skipStatusChecks: {}, filters: {}", request.isSkipStatusChecks(), request.getStatusCheckFilters());
+    public VCVerificationResultDto verifyV2(VCVerificationRequestDto request, boolean validateKeyBindingJwt) {
+        log.debug("Processing verification request with skipStatusChecks: {}, filters: {}, validateKeyBindingJwt: {}", request.isSkipStatusChecks(), request.getStatusCheckFilters(), validateKeyBindingJwt);
         String verifiableCredential = request.getVerifiableCredential();
         CredentialFormat format = Utils.getCredentialFormat(verifiableCredential);
         VerificationResult verificationResult;
@@ -76,15 +77,15 @@ public class VCVerificationServiceImpl implements VCVerificationService {
         Map<String, Object> claims = Map.of();
 
         boolean skipStatusChecks = request.isSkipStatusChecks();
-            if (skipStatusChecks) {
-                verificationResult = credentialsVerifier.verify(verifiableCredential, format);
-            } else {
-                List<String> statusCheckFilters = request.getStatusCheckFilters();
-                CredentialVerificationSummary credentialVerificationSummary =
-                        credentialsVerifier.verifyAndGetCredentialStatus(verifiableCredential, format, statusCheckFilters);
-                verificationResult = credentialVerificationSummary.getVerificationResult();
-                credentialStatus = credentialVerificationSummary.getCredentialStatus();
-            }
+        if (skipStatusChecks) {
+            verificationResult = credentialsVerifier.verify(verifiableCredential, format, validateKeyBindingJwt);
+        } else {
+            List<String> statusCheckFilters = request.getStatusCheckFilters();
+            CredentialVerificationSummary credentialVerificationSummary =
+                    credentialsVerifier.verifyAndGetCredentialStatus(verifiableCredential, format, statusCheckFilters, validateKeyBindingJwt);
+            verificationResult = credentialVerificationSummary.getVerificationResult();
+            credentialStatus = credentialVerificationSummary.getCredentialStatus();
+        }
 
         SchemaAndSignatureCheckDto schemaAndSignatureCheck = populateSchemaAndSignature(verificationResult);
         if (schemaAndSignatureCheck.isValid()) {

--- a/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImpl.java
+++ b/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImpl.java
@@ -228,75 +228,89 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
      * @param ldpVpTokens
      * @return
      */
-    public boolean isClientIdValid(AuthorizationRequestResponseDto authRequest, Map<String, List<JSONObject>> ldpVpTokens) {
-        log.info("Validating client_id from VP token");
+    /**
+     * Validates client_id and nonce for LDP VP tokens in a single pass.
+     * Checks {@code proof.domain} against the auth request clientId and
+     * {@code proof.challenge} against the auth request nonce.
+     * Returns the first {@link ErrorCode} encountered, or null if all tokens pass.
+     */
+    @Override
+    public ErrorCode processLdpVpClientIdAndNonce(AuthorizationRequestResponseDto authRequest, Map<String, List<JSONObject>> ldpVpTokens) {
         String clientId = authRequest.getClientId();
+        String nonce = authRequest.getNonce();
         if (!StringUtils.hasText(clientId)) {
-            log.error("clientId is missing");
-            return false;
+            log.error("clientId is missing in auth request");
+            return ErrorCode.CLIENT_ID_VALIDATION_FAILED;
         }
-        // client_id validation is done only for LDP VP tokens since SD-JWT tokens
-        // are self-contained and do not have a proof with a domain claim.
+        if (!StringUtils.hasText(nonce)) {
+            log.error("nonce is missing in auth request");
+            return ErrorCode.NONCE_VALIDATION_FAILED;
+        }
         for (Map.Entry<String, List<JSONObject>> entry : ldpVpTokens.entrySet()) {
             String queryId = entry.getKey();
             for (JSONObject jsonVPToken : entry.getValue()) {
-                log.debug("Processing query ID: {}", queryId);
+                log.debug("Processing LDP VP token for query ID: {}", queryId);
                 JSONObject proof = jsonVPToken.optJSONObject("proof");
                 String domain = proof != null ? proof.optString("domain", null) : null;
-                log.debug("domain: {}, expected clientId: {}", domain, clientId);
                 if (!Objects.equals(clientId, domain)) {
-                    log.error(
-                            "clientId validation failed for query ID: {}, expected: {}, actual: {}",
-                            queryId,
-                            clientId,
-                            domain
-                    );
-                    return false;
+                    log.error("clientId validation failed for query ID: {}, expected: {}, actual: {}", queryId, clientId, domain);
+                    return ErrorCode.CLIENT_ID_VALIDATION_FAILED;
+                }
+                String challenge = proof != null ? proof.optString("challenge", null) : null;
+                if (!Objects.equals(nonce, challenge)) {
+                    log.error("nonce validation failed for query ID: {}, expected: {}, actual: {}", queryId, nonce, challenge);
+                    return ErrorCode.NONCE_VALIDATION_FAILED;
                 }
             }
         }
-        return true;
+        return null;
     }
 
     /**
-     *  This method validates the nonce from the VP token against the nonce in the authorization request.
-     *  If the authorization request allows accepting VP without holder proof, it skips nonce validation and returns true.
-     *  If nonce validation is required, it checks if the nonce in the proof's challenge claim of each LDP VP token matches the nonce in the authorization request.
-     *  If any of the tokens fail this validation, it returns false.
-     *  For SD-JWT tokens, since they are self-contained and do not have a proof with a challenge claim, nonce validation is not performed on them.
-     *
-     * @param authRequest
-     * @param ldpVpTokens
-     * @return
+     * Validates client_id and nonce for SD-JWT tokens in a single pass.
+     * When {@code require_cryptographic_holder_binding=true} for a query ID,
+     * extracts the KB-JWT once per token and checks both {@code aud} against
+     * the auth request clientId and {@code nonce} against the auth request nonce
+     * (OpenID4VP Appendix B.3.6).
+     * Returns the first {@link ErrorCode} encountered, or null if all tokens pass.
      */
-    public boolean isNonceValid(AuthorizationRequestResponseDto authRequest, Map<String, List<JSONObject>> ldpVpTokens) {
+    @Override
+    public ErrorCode processSdJwtClientIdAndNonce(AuthorizationRequestResponseDto authRequest, Map<String, List<String>> sdJwtTokens) {
+        String clientId = authRequest.getClientId();
         String nonce = authRequest.getNonce();
-        if (!StringUtils.hasText(nonce)) {
-            log.error("nonce is missing");
-            return false;
+        if (!StringUtils.hasText(clientId)) {
+            log.error("clientId is missing in auth request");
+            return ErrorCode.CLIENT_ID_VALIDATION_FAILED;
         }
-        // nonce validation is done only for LDP VP tokens since SD-JWT tokens
-        // are self-contained and do not have a proof with challenge claim.
-        for (Map.Entry<String, List<JSONObject>> entry : ldpVpTokens.entrySet()) {
+        if (!StringUtils.hasText(nonce)) {
+            log.error("nonce is missing in auth request");
+            return ErrorCode.NONCE_VALIDATION_FAILED;
+        }
+        for (Map.Entry<String, List<String>> entry : sdJwtTokens.entrySet()) {
             String queryId = entry.getKey();
-            log.info("Performing nonce validation for query ID {} since require_cryptographic_holder_binding is true", queryId);
-            for (JSONObject jsonVPToken : entry.getValue()) {
-                log.debug("Processing query ID: {}", queryId);
-                JSONObject proof = jsonVPToken.optJSONObject("proof");
-                String challenge = proof != null ? proof.optString("challenge", null) : null;
-                log.debug("challenge: {}, expected nonce: {}", challenge, nonce);
-                if (!Objects.equals(nonce, challenge)) {
-                    log.error(
-                            "nonce validation failed for query ID: {}, expected: {}, actual: {}",
-                            queryId,
-                            nonce,
-                            challenge
-                    );
-                    return false;
+            if (!isCryptographicHolderBindingRequired(authRequest, queryId)) {
+                log.debug("Skipping KB-JWT validation for query ID {} since require_cryptographic_holder_binding is false", queryId);
+                continue;
+            }
+            for (String sdJwt : entry.getValue()) {
+                JSONObject kbPayload = Utils.extractKbJwtPayload(sdJwt);
+                if (kbPayload == null) {
+                    log.error("KB-JWT payload could not be decoded for query ID: {}", queryId);
+                    return ErrorCode.CLIENT_ID_VALIDATION_FAILED;
+                }
+                String audClaim = kbPayload.optString("aud", null);
+                if (!Objects.equals(clientId, audClaim)) {
+                    log.error("KB-JWT aud mismatch for query ID: {}, expected: {}, actual: {}", queryId, clientId, audClaim);
+                    return ErrorCode.CLIENT_ID_VALIDATION_FAILED;
+                }
+                String kbNonce = kbPayload.optString("nonce", null);
+                if (!Objects.equals(nonce, kbNonce)) {
+                    log.error("KB-JWT nonce mismatch for query ID: {}, expected: {}, actual: {}", queryId, nonce, kbNonce);
+                    return ErrorCode.NONCE_VALIDATION_FAILED;
                 }
             }
         }
-        return true;
+        return null;
     }
 
     /**
@@ -389,14 +403,14 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
                         Object verifiableCredential = vpToken.opt("verifiableCredential");
                         List<Object> listOfVerifiableCredentials = getListOfVerifiableCredentials(verifiableCredential);
                         for (Object credential : listOfVerifiableCredentials) {
-                            verifyAndGetCredentialStatus(credential.toString(), verificationResults, CredentialFormat.LDP_VC);
+                            verifyAndGetCredentialStatus(credential.toString(), verificationResults, CredentialFormat.LDP_VC, false);
                         }
                     } else {
                         throw new VPWithoutProofException();
                     }
                 }
                 for (String sdJwtVpToken : vpTokenDto.getSdJwtVpTokens()) {
-                    verifyAndGetCredentialStatus(sdJwtVpToken, verificationResults, CredentialFormat.VC_SD_JWT);
+                    verifyAndGetCredentialStatus(sdJwtVpToken, verificationResults, CredentialFormat.DC_SD_JWT, !acceptVPWithoutHolderProof);
                 }
             } else {
                 log.info("Authorization request does not contain presentation exchange, processing VP token as DCQL query response");
@@ -416,14 +430,15 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
                     log.info("Processing LDP VC tokens for query ID: {}", queryId);
                     for (JSONObject ldpVcToken : entry.getValue()) {
                         String ldpVcString = ldpVcToken.toString();
-                        verifyAndGetCredentialStatus(ldpVcString, verificationResults, CredentialFormat.LDP_VC);
+                        verifyAndGetCredentialStatus(ldpVcString, verificationResults, CredentialFormat.LDP_VC, false);
                     }
                 }
                 for (Map.Entry<String, List<String>> entry : sdJwtTokens.entrySet()) {
                     String queryId = entry.getKey();
                     log.info("Processing SD-JWT tokens for query ID: {}", queryId);
+                    boolean requireCryptographicHolderBinding = isCryptographicHolderBindingRequired(authRequest.getAuthorizationDetails(), queryId);
                     for (String sdJwtToken : entry.getValue()) {
-                        verifyAndGetCredentialStatus(sdJwtToken, verificationResults, CredentialFormat.DC_SD_JWT);
+                        verifyAndGetCredentialStatus(sdJwtToken, verificationResults, CredentialFormat.DC_SD_JWT, requireCryptographicHolderBinding);
                     }
                 }
             }
@@ -472,14 +487,14 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
                         Object verifiableCredential = ldpVpToken.opt("verifiableCredential");
                         List<Object> listOfVerifiableCredentials = getListOfVerifiableCredentials(verifiableCredential);
                         for (Object credential : listOfVerifiableCredentials) {
-                            credentialResults.add(verifyAndGetCredentialStatusV2(request, credential, false));
+                            credentialResults.add(verifyAndGetCredentialStatusV2(request, credential, false, false));
                         }
                     } else {
                         throw new VPWithoutProofException();
                     }
                 }
                 for (String sdJwtVpToken : vpTokenDto.getSdJwtVpTokens()) {
-                    credentialResults.add(verifyAndGetCredentialStatusV2(request, sdJwtVpToken, true));
+                    credentialResults.add(verifyAndGetCredentialStatusV2(request, sdJwtVpToken, true, !acceptVPWithoutHolderProof));
                 }
             } else {
                 log.info("Authorization request does not contain presentation exchange, processing VP token as DCQL query response");
@@ -503,14 +518,15 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
                     log.info("Processing LDP VC tokens for query ID: {}", queryId);
                     for (JSONObject ldpVcToken : entry.getValue()) {
                         String ldpVcString = ldpVcToken.toString();
-                        credentialResults.add(verifyAndGetCredentialStatusV2(request, ldpVcString, false));
+                        credentialResults.add(verifyAndGetCredentialStatusV2(request, ldpVcString, false, false));
                     }
                 }
                 for (Map.Entry<String, List<String>> entry : sdJwtTokens.entrySet()) {
                     String queryId = entry.getKey();
                     log.info("Processing SD-JWT tokens for query ID: {}", queryId);
+                    boolean requireCryptographicHolderBinding = isCryptographicHolderBindingRequired(authRequest.getAuthorizationDetails(), queryId);
                     for (String sdJwtToken : entry.getValue()) {
-                        credentialResults.add(verifyAndGetCredentialStatusV2(request, sdJwtToken, true));
+                        credentialResults.add(verifyAndGetCredentialStatusV2(request, sdJwtToken, true, requireCryptographicHolderBinding));
                     }
                 }
             }
@@ -521,8 +537,8 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
             log.error("Failed to process VP submission V2", ex);
             throw ex;
         } catch (Exception ex) {
-            log.error("Failed to process VP submission V2", ex);
-            throw new VPVerificationException();
+            log.error("Failed to process VP submission V2", ex.toString());
+            throw new VPVerificationException(ex);
         }
     }
 
@@ -605,10 +621,14 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
         return Optional.ofNullable(request.getAuthorizationDetails()).map(AuthorizationRequestResponseDto::isAcceptVPWithoutHolderProof).orElse(false);
     }
 
-    private void verifyAndGetCredentialStatus(String vc, List<VCResultDto> verificationResults, CredentialFormat credentialFormat) {
+    private void verifyAndGetCredentialStatus(String vc, List<VCResultDto> verificationResults, CredentialFormat credentialFormat, boolean requireCryptographicHolderBinding) {
         List<String> statusPurposeList = new ArrayList<>();
         statusPurposeList.add(Constants.STATUS_PURPOSE_REVOKED);
-        CredentialVerificationSummary credentialVerificationSummary = credentialsVerifier.verifyAndGetCredentialStatus(vc, credentialFormat, statusPurposeList);
+        boolean validateKbJwt = false;
+        if (requireCryptographicHolderBinding && CredentialFormat.DC_SD_JWT.equals(credentialFormat)) {
+            validateKbJwt = true;
+        }
+        CredentialVerificationSummary credentialVerificationSummary = credentialsVerifier.verifyAndGetCredentialStatus(vc, credentialFormat, statusPurposeList, validateKbJwt);
         VerificationResult verificationResult = credentialVerificationSummary.getVerificationResult();
         if (!verificationResult.getVerificationStatus()) {
             log.error("VC Verification Failed");
@@ -704,6 +724,7 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
     public VPVerificationResultDto getVPResultV2(VerificationRequestDto request, List<String> requestIds, String transactionId) {
         AuthorizationRequestCreateResponse authRequest = verifiablePresentationRequestService.getLatestAuthorizationRequestFor(transactionId);
         VPSubmission vpSubmission = fetchVpSubmissionIfValid(requestIds, null, authRequest, false);
+        log.info(vpSubmission.getVpToken().toString());
         return processSubmissionV2(request, transactionId, vpSubmission, authRequest);
     }
 
@@ -738,13 +759,17 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
         return combinedVerificationStatus ? VPResultStatus.SUCCESS : VPResultStatus.FAILED;
     }
 
-    private CredentialResultsDto verifyAndGetCredentialStatusV2(VerificationRequestDto request, Object vc, boolean isSdJwt) {
+    private CredentialResultsDto verifyAndGetCredentialStatusV2(VerificationRequestDto request, Object vc, boolean isSdJwt, boolean requireCryptographicHolderBinding) {
         VCVerificationRequestDto vcVerificationRequestDto = new VCVerificationRequestDto(vc.toString());
         vcVerificationRequestDto.setSkipStatusChecks(request.isSkipStatusChecks());
         vcVerificationRequestDto.setStatusCheckFilters(request.getStatusCheckFilters());
         vcVerificationRequestDto.setIncludeClaims(request.isIncludeClaims());
 
-        VCVerificationResultDto resultDto = vcVerificationService.verifyV2(vcVerificationRequestDto);
+        boolean validateKbJwt = false;
+        if (requireCryptographicHolderBinding && isSdJwt) {
+            validateKbJwt = true;
+        }
+        VCVerificationResultDto resultDto = vcVerificationService.verifyV2(vcVerificationRequestDto, validateKbJwt);
 
         CredentialResultsDto credentialResults = new CredentialResultsDto();
         credentialResults.setVerifiableCredential(vc.toString());
@@ -753,7 +778,7 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
         credentialResults.setExpiryCheck(resultDto.getExpiryCheck());
         credentialResults.setStatusCheck(resultDto.getStatusCheck());
         credentialResults.setClaims(resultDto.getClaims());
-        if (isSdJwt) {
+        if (isSdJwt && validateKbJwt) {
             SchemaAndSignatureCheckDto schemaAndSignatureCheck = resultDto.getSchemaAndSignatureCheck();
             if (schemaAndSignatureCheck.isValid()) {
                 credentialResults.setHolderProofCheck(new HolderProofCheckDto(true, null));
@@ -767,7 +792,7 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
                     }
                 }
             }
-        } else {
+        }  else {
             credentialResults.setHolderProofCheck(null);
         }
 

--- a/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImpl.java
+++ b/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImpl.java
@@ -537,7 +537,7 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
             log.error("Failed to process VP submission V2", ex);
             throw ex;
         } catch (Exception ex) {
-            log.error("Failed to process VP submission V2", ex.toString());
+            log.error("Failed to process VP submission V2", ex);
             throw new VPVerificationException(ex);
         }
     }
@@ -724,7 +724,7 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
     public VPVerificationResultDto getVPResultV2(VerificationRequestDto request, List<String> requestIds, String transactionId) {
         AuthorizationRequestCreateResponse authRequest = verifiablePresentationRequestService.getLatestAuthorizationRequestFor(transactionId);
         VPSubmission vpSubmission = fetchVpSubmissionIfValid(requestIds, null, authRequest, false);
-        log.info(vpSubmission.getVpToken().toString());
+        log.debug("Processing VP submission, token length: {}", vpSubmission.getVpToken() != null ? vpSubmission.getVpToken().toString().length() : 0);
         return processSubmissionV2(request, transactionId, vpSubmission, authRequest);
     }
 

--- a/verify-service/src/main/java/io/inji/verify/utils/Utils.java
+++ b/verify-service/src/main/java/io/inji/verify/utils/Utils.java
@@ -110,6 +110,25 @@ public final class Utils {
     }
 
     /**
+     * Decodes and returns the payload of the Key Binding JWT (KB-JWT) from an SD-JWT string.
+     * The KB-JWT is the last '~'-delimited segment and must itself be a three-part JWT.
+     * Returns null if the KB-JWT is absent, malformed, or its payload cannot be decoded.
+     */
+    public static JSONObject extractKbJwtPayload(String sdJwt) {
+        String[] parts = sdJwt.split("~", -1);
+        String kbJwt = parts[parts.length - 1];
+        if (kbJwt.isEmpty()) return null;
+        String[] jwtParts = kbJwt.split("\\.");
+        if (jwtParts.length != 3) return null;
+        try {
+            String payloadJson = decodeBase64Json(jwtParts[1]);
+            return new JSONObject(payloadJson);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
      * Checks whether an SD-JWT string contains a Key Binding JWT (KB-JWT).
      * Per the IETF SD-JWT spec, the KB-JWT is the last ~-delimited part and is itself a full JWT
      * (three Base64url segments separated by dots). An SD-JWT without a KB-JWT ends with a trailing ~

--- a/verify-service/src/test/java/io/inji/verify/controller/VPSubmissionControllerTest.java
+++ b/verify-service/src/test/java/io/inji/verify/controller/VPSubmissionControllerTest.java
@@ -275,8 +275,8 @@ class VPSubmissionControllerTest {
         when(vpSubmissionService.extractDcqlTokens(any(),any()))
                 .thenReturn(mockDcqlTokens());
 
-        when(vpSubmissionService.isClientIdValid(any(), any()))
-                .thenReturn(false);
+        when(vpSubmissionService.processLdpVpClientIdAndNonce(any(), any()))
+                .thenReturn(ErrorCode.CLIENT_ID_VALIDATION_FAILED);
 
         ResponseEntity<?> response =
                 controller.submitVP(VALID_VP_TOKEN, STATE, null, null, request);
@@ -315,11 +315,8 @@ class VPSubmissionControllerTest {
         when(vpSubmissionService.extractDcqlTokens(any(), any()))
                 .thenReturn(mockDcqlTokens());
 
-        when(vpSubmissionService.isClientIdValid(any(), any()))
-                .thenReturn(true);
-
-        when(vpSubmissionService.isNonceValid(any(), any()))
-                .thenReturn(false);
+        when(vpSubmissionService.processLdpVpClientIdAndNonce(any(), any()))
+                .thenReturn(ErrorCode.NONCE_VALIDATION_FAILED);
 
         ResponseEntity<?> response =
                 controller.submitVP(VALID_VP_TOKEN, STATE, null, null, request);
@@ -358,11 +355,8 @@ class VPSubmissionControllerTest {
         when(vpSubmissionService.extractDcqlTokens(any(), any()))
                 .thenReturn(mockDcqlTokens());
 
-        when(vpSubmissionService.isClientIdValid(any(), any()))
-                .thenReturn(true);
-
-        when(vpSubmissionService.isNonceValid(any(), any()))
-                .thenReturn(true);
+        when(vpSubmissionService.processLdpVpClientIdAndNonce(any(), any()))
+                .thenReturn(null);
 
         when(vpSubmissionService.generateResponseCode(any()))
                 .thenReturn("resp-code");
@@ -403,11 +397,8 @@ class VPSubmissionControllerTest {
         when(vpSubmissionService.extractDcqlTokens(any(), any()))
                 .thenReturn(mockDcqlTokens());
 
-        when(vpSubmissionService.isClientIdValid(any(), any()))
-                .thenReturn(true);
-
-        when(vpSubmissionService.isNonceValid(any(), any()))
-                .thenReturn(true);
+        when(vpSubmissionService.processLdpVpClientIdAndNonce(any(), any()))
+                .thenReturn(null);
 
         doThrow(new VPAlreadySubmittedException())
                 .when(vpSubmissionService)
@@ -520,14 +511,73 @@ class VPSubmissionControllerTest {
         when(vpSubmissionService.extractDcqlTokens(any(),any()))
                 .thenReturn(mockDcqlTokens());
 
-        when(vpSubmissionService.isClientIdValid(any(), any()))
-                .thenReturn(true);
-
-        when(vpSubmissionService.isNonceValid(any(), any()))
-                .thenReturn(true);
+        when(vpSubmissionService.processLdpVpClientIdAndNonce(any(), any()))
+                .thenReturn(null);
 
         ResponseEntity<?> response =
                 controller.submitVP(VALID_VP_TOKEN, STATE, null, null, request);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(vpSubmissionService).submitVpToken(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    // ---- SD-JWT KB-JWT validation tests ----
+
+    private DcqlTokensDto mockSdJwtTokens() {
+        Map<String, List<String>> sdJwtTokens = new HashMap<>();
+        sdJwtTokens.put("cred1", Collections.singletonList("header.payload.sig~kb-header.kb-payload.kb-sig"));
+        return new DcqlTokensDto(new HashMap<>(), new HashMap<>(), sdJwtTokens);
+    }
+
+    private AuthorizationRequestCreateResponse mockActiveAuth() {
+        AuthorizationRequestCreateResponse auth = mock(AuthorizationRequestCreateResponse.class);
+        AuthorizationRequestResponseDto authDetails = mock(AuthorizationRequestResponseDto.class);
+        when(auth.getAuthorizationDetails()).thenReturn(authDetails);
+        when(vpRequestService.getCurrentRequestStatus(STATE))
+                .thenReturn(new VPRequestStatusDto(VPRequestStatus.ACTIVE));
+        when(vpSubmissionService.getAuthRequest(STATE)).thenReturn(auth);
+        when(vpSubmissionService.extractDcqlTokens(any(), any())).thenReturn(mockSdJwtTokens());
+        return auth;
+    }
+
+    @Test
+    void shouldReturnBadRequest_whenSdJwtKbJwtClientIdFails() {
+        mockActiveAuth();
+
+        when(vpSubmissionService.processSdJwtClientIdAndNonce(any(), any()))
+                .thenReturn(ErrorCode.CLIENT_ID_VALIDATION_FAILED);
+
+        ResponseEntity<?> response = controller.submitVP(VALID_VP_TOKEN, STATE, null, null, request);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        ErrorDto body = (ErrorDto) response.getBody();
+        assertNotNull(body);
+        assertEquals(ErrorCode.CLIENT_ID_VALIDATION_FAILED.getErrorCode(), body.getErrorCode());
+    }
+
+    @Test
+    void shouldReturnBadRequest_whenSdJwtKbJwtNonceFails() {
+        mockActiveAuth();
+
+        when(vpSubmissionService.processSdJwtClientIdAndNonce(any(), any()))
+                .thenReturn(ErrorCode.NONCE_VALIDATION_FAILED);
+
+        ResponseEntity<?> response = controller.submitVP(VALID_VP_TOKEN, STATE, null, null, request);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        ErrorDto body = (ErrorDto) response.getBody();
+        assertNotNull(body);
+        assertEquals(ErrorCode.NONCE_VALIDATION_FAILED.getErrorCode(), body.getErrorCode());
+    }
+
+    @Test
+    void shouldProceed_whenSdJwtKbJwtValid() {
+        AuthorizationRequestCreateResponse auth = mockActiveAuth();
+        when(auth.getAuthorizationDetails()).thenReturn(mock(AuthorizationRequestResponseDto.class));
+
+        when(vpSubmissionService.processSdJwtClientIdAndNonce(any(), any())).thenReturn(null);
+
+        ResponseEntity<?> response = controller.submitVP(VALID_VP_TOKEN, STATE, null, null, request);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         verify(vpSubmissionService).submitVpToken(any(), any(), any(), any(), any(), any(), any());

--- a/verify-service/src/test/java/io/inji/verify/services/impl/VCSubmissionServiceImplTest.java
+++ b/verify-service/src/test/java/io/inji/verify/services/impl/VCSubmissionServiceImplTest.java
@@ -105,7 +105,7 @@ public class VCSubmissionServiceImplTest {
         when(credentialsVerifier.verifyAndGetCredentialStatus(
                 eq(TEST_VC_STRING),
                 eq(CredentialFormat.LDP_VC),
-                anyList())
+                anyList(), eq(false))
         ).thenReturn(credentialVerificationSummary);
 
         try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
@@ -123,7 +123,8 @@ public class VCSubmissionServiceImplTest {
             verify(credentialsVerifier, times(1)).verifyAndGetCredentialStatus(
                     eq(TEST_VC_STRING),
                     eq(CredentialFormat.LDP_VC),
-                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED))
+                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED)),
+                    eq(false)
             );
             utilsMock.verify(() -> Utils.getVcVerificationStatus(credentialVerificationSummary), times(1));
         }
@@ -138,7 +139,7 @@ public class VCSubmissionServiceImplTest {
         when(credentialsVerifier.verifyAndGetCredentialStatus(
                 eq(TEST_SDJWT_VC_STRING),
                 eq(CredentialFormat.VC_SD_JWT),
-                anyList())
+                anyList(), eq(false))
         ).thenReturn(credentialVerificationSummary);
 
         try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
@@ -156,7 +157,8 @@ public class VCSubmissionServiceImplTest {
             verify(credentialsVerifier, times(1)).verifyAndGetCredentialStatus(
                     eq(TEST_SDJWT_VC_STRING),
                     eq(CredentialFormat.VC_SD_JWT),
-                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED))
+                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED)),
+                    eq(false)
             );
             utilsMock.verify(() -> Utils.getVcVerificationStatus(credentialVerificationSummary), times(1));
         }
@@ -172,7 +174,7 @@ public class VCSubmissionServiceImplTest {
         when(credentialsVerifier.verifyAndGetCredentialStatus(
                 eq(TEST_VC_STRING),
                 eq(CredentialFormat.LDP_VC),
-                anyList())
+                anyList(), eq(false))
         ).thenReturn(credentialVerificationSummary);
 
         try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
@@ -192,7 +194,8 @@ public class VCSubmissionServiceImplTest {
             verify(credentialsVerifier, times(1)).verifyAndGetCredentialStatus(
                     eq(TEST_VC_STRING),
                     eq(CredentialFormat.LDP_VC),
-                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED))
+                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED)),
+                    eq(false)
             );
             utilsMock.verify(() -> Utils.getVcVerificationStatus(credentialVerificationSummary), times(1));
         }
@@ -207,7 +210,7 @@ public class VCSubmissionServiceImplTest {
         when(credentialsVerifier.verifyAndGetCredentialStatus(
                 eq(TEST_SDJWT_VC_STRING),
                 eq(CredentialFormat.VC_SD_JWT),
-                anyList())
+                anyList(), eq(false))
         ).thenReturn(credentialVerificationSummary);
 
         try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
@@ -226,7 +229,8 @@ public class VCSubmissionServiceImplTest {
             verify(credentialsVerifier, times(1)).verifyAndGetCredentialStatus(
                     eq(TEST_SDJWT_VC_STRING),
                     eq(CredentialFormat.VC_SD_JWT),
-                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED))
+                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED)),
+                    eq(false)
             );
             utilsMock.verify(() -> Utils.getVcVerificationStatus(credentialVerificationSummary), times(1));
         }
@@ -241,7 +245,7 @@ public class VCSubmissionServiceImplTest {
         when(credentialsVerifier.verifyAndGetCredentialStatus(
                 eq(TEST_VC_STRING),
                 eq(CredentialFormat.LDP_VC),
-                anyList())
+                anyList(), eq(false))
         ).thenReturn(credentialVerificationSummary);
 
         try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
@@ -261,7 +265,8 @@ public class VCSubmissionServiceImplTest {
             verify(credentialsVerifier, times(1)).verifyAndGetCredentialStatus(
                     eq(TEST_VC_STRING),
                     eq(CredentialFormat.LDP_VC),
-                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED))
+                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED)),
+                    eq(false)
             );
             utilsMock.verify(() -> Utils.getVcVerificationStatus(credentialVerificationSummary), times(1));
         }
@@ -276,7 +281,7 @@ public class VCSubmissionServiceImplTest {
         when(credentialsVerifier.verifyAndGetCredentialStatus(
                 eq(TEST_SDJWT_VC_STRING),
                 eq(CredentialFormat.VC_SD_JWT),
-                anyList())
+                anyList(), eq(false))
         ).thenReturn(credentialVerificationSummary);
 
         try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
@@ -295,7 +300,8 @@ public class VCSubmissionServiceImplTest {
             verify(credentialsVerifier, times(1)).verifyAndGetCredentialStatus(
                     eq(TEST_SDJWT_VC_STRING),
                     eq(CredentialFormat.VC_SD_JWT),
-                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED))
+                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED)),
+                    eq(false)
             );
             utilsMock.verify(() -> Utils.getVcVerificationStatus(credentialVerificationSummary), times(1));
         }
@@ -322,7 +328,7 @@ public class VCSubmissionServiceImplTest {
         when(credentialsVerifier.verifyAndGetCredentialStatus(
                 eq(TEST_VC_STRING),
                 eq(CredentialFormat.LDP_VC),
-                anyList())
+                anyList(), eq(false))
         ).thenReturn(credentialVerificationSummary);
 
         try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
@@ -341,7 +347,8 @@ public class VCSubmissionServiceImplTest {
             verify(credentialsVerifier, times(1)).verifyAndGetCredentialStatus(
                     eq(TEST_VC_STRING),
                     eq(CredentialFormat.LDP_VC),
-                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED))
+                    argThat(list -> list.contains(Constants.STATUS_PURPOSE_REVOKED)),
+                    eq(false)
             );
             utilsMock.verify(() -> Utils.getVcVerificationStatus(credentialVerificationSummary), times(1));
         }

--- a/verify-service/src/test/java/io/inji/verify/services/impl/VCVerificationServiceImplTest.java
+++ b/verify-service/src/test/java/io/inji/verify/services/impl/VCVerificationServiceImplTest.java
@@ -47,7 +47,7 @@ public class VCVerificationServiceImplTest {
             when(mockCredentialsVerifier.verifyAndGetCredentialStatus(
                     eq(TEST_JSON_VC_STRING),
                     eq(CredentialFormat.LDP_VC),
-                    anyList()))
+                    anyList(), anyBoolean()))
                     .thenReturn(summary);
 
                 VCVerificationStatusDto result = service.verify(TEST_JSON_VC_STRING, "application/ldp+json");
@@ -64,7 +64,7 @@ public class VCVerificationServiceImplTest {
             when(mockCredentialsVerifier.verifyAndGetCredentialStatus(
                     eq(TEST_JSON_VC_STRING),
                     eq(CredentialFormat.LDP_VC),
-                    anyList()))
+                    anyList(), anyBoolean()))
                     .thenReturn(summary);
 
                 VCVerificationStatusDto result = service.verify(TEST_JSON_VC_STRING, "application/ldp+json");
@@ -86,7 +86,7 @@ public class VCVerificationServiceImplTest {
             when(mockCredentialsVerifier.verifyAndGetCredentialStatus(
                     eq(TEST_JSON_VC_STRING),
                     eq(CredentialFormat.LDP_VC),
-                    anyList()))
+                    anyList(), anyBoolean()))
                     .thenReturn(summary);
 
                 VCVerificationStatusDto result = service.verify(TEST_JSON_VC_STRING, "application/ldp+json");
@@ -104,7 +104,7 @@ public class VCVerificationServiceImplTest {
             when(mockCredentialsVerifier.verifyAndGetCredentialStatus(
                     eq(TEST_JSON_VC_STRING),
                     eq(CredentialFormat.LDP_VC),
-                    anyList())
+                    anyList(), anyBoolean())
             ).thenReturn(summary);
 
                 VCVerificationStatusDto statusDto = service.verify(TEST_JSON_VC_STRING, "application/other");
@@ -125,7 +125,7 @@ public class VCVerificationServiceImplTest {
             when(mockCredentialsVerifier.verifyAndGetCredentialStatus(
                     eq(TEST_JSON_VC_STRING),
                     eq(CredentialFormat.LDP_VC),
-                    anyList()))
+                    anyList(), anyBoolean()))
                     .thenReturn(summary);
             when(vResult.getVerificationMessage()).thenReturn("EXPIRED");
             when(vResult.getVerificationErrorCode()).thenReturn("ERR_VC_EXPIRED");
@@ -145,7 +145,7 @@ public class VCVerificationServiceImplTest {
             when(mockCredentialsVerifier.verifyAndGetCredentialStatus(
                     eq(TEST_CWT_VC_STRING),
                     eq(CredentialFormat.CWT_VC),
-                    anyList()))
+                    anyList(), anyBoolean()))
                     .thenReturn(summary);
 
                 VCVerificationStatusDto result = service.verify(TEST_CWT_VC_STRING, "application/vc+cwt");
@@ -163,7 +163,7 @@ public class VCVerificationServiceImplTest {
             when(mockCredentialsVerifier.verifyAndGetCredentialStatus(
                     eq(TEST_CWT_VC_STRING),
                     eq(CredentialFormat.CWT_VC),
-                    anyList()))
+                    anyList(), anyBoolean()))
                     .thenReturn(summary);
 
                 VCVerificationStatusDto result = service.verify(TEST_CWT_VC_STRING, "application/vc+cwt");
@@ -186,7 +186,7 @@ public class VCVerificationServiceImplTest {
             when(mockCredentialsVerifier.verifyAndGetCredentialStatus(
                     eq(TEST_CWT_VC_STRING),
                     eq(CredentialFormat.CWT_VC),
-                    anyList()))
+                    anyList(), anyBoolean()))
                     .thenReturn(summary);
 
                 VCVerificationStatusDto result = service.verify(TEST_CWT_VC_STRING, "application/vc+cwt");
@@ -207,7 +207,7 @@ public class VCVerificationServiceImplTest {
             when(mockCredentialsVerifier.verifyAndGetCredentialStatus(
                     eq(TEST_CWT_VC_STRING),
                     eq(CredentialFormat.CWT_VC),
-                    anyList()))
+                    anyList(), anyBoolean()))
                     .thenReturn(summary);
             when(vResult.getVerificationMessage()).thenReturn("EXPIRED");
             when(vResult.getVerificationErrorCode()).thenReturn("ERR_VC_EXPIRED");
@@ -228,7 +228,7 @@ public class VCVerificationServiceImplTest {
 
             VerificationResult verificationResult = mock(VerificationResult.class);
             when(verificationResult.getVerificationStatus()).thenReturn(true);
-            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class)))
+            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class), anyBoolean()))
                     .thenReturn(verificationResult);
 
             try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
@@ -236,7 +236,7 @@ public class VCVerificationServiceImplTest {
                 utilsMock.when(() -> Utils.populateSchemaAndSignature(any())).thenReturn(new SchemaAndSignatureCheckDto(true, null));
                 utilsMock.when(() -> Utils.populateExpiryCheck(any())).thenReturn(new ExpiryCheckDto(true));
                 utilsMock.when(() -> Utils.populateAllChecksSuccessful(any(), any(), any(), any())).thenCallRealMethod();
-                VCVerificationResultDto result = service.verifyV2(request);
+                VCVerificationResultDto result = service.verifyV2(request, false);
 
                 assertTrue(result.isAllChecksSuccessful());
                 assertTrue(result.getSchemaAndSignatureCheck().isValid());
@@ -256,14 +256,14 @@ public class VCVerificationServiceImplTest {
             CredentialVerificationSummary summary = mock(CredentialVerificationSummary.class);
             when(summary.getVerificationResult()).thenReturn(verificationResult);
             when(summary.getCredentialStatus()).thenReturn(Map.of("revocation", statusResult));
-            when(mockCredentialsVerifier.verifyAndGetCredentialStatus(anyString(), any(CredentialFormat.class), anyList()))
+            when(mockCredentialsVerifier.verifyAndGetCredentialStatus(anyString(), any(CredentialFormat.class), anyList(), anyBoolean()))
                     .thenReturn(summary);
 
             try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
                 utilsMock.when(() -> Utils.getCredentialFormat(TEST_JSON_VC_STRING)).thenReturn(CredentialFormat.LDP_VC);
                 utilsMock.when(() -> Utils.populateSchemaAndSignature(any())).thenReturn(new SchemaAndSignatureCheckDto(true, null));
                 utilsMock.when(() -> Utils.populateExpiryCheck(any())).thenReturn(new ExpiryCheckDto(true));
-                VCVerificationResultDto result = service.verifyV2(request);
+                VCVerificationResultDto result = service.verifyV2(request, false);
 
                 assertFalse(result.isAllChecksSuccessful());
                 assertTrue(result.getSchemaAndSignatureCheck().isValid());
@@ -283,14 +283,14 @@ public class VCVerificationServiceImplTest {
             when(verificationResult.getVerificationMessage()).thenReturn("Some error message");
 
 
-            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class)))
+            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class), anyBoolean()))
                     .thenReturn(verificationResult);
 
             try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
                 utilsMock.when(() -> Utils.isSdJwt(anyString())).thenReturn(false);
                 utilsMock.when(() -> Utils.populateSchemaAndSignature(any())).thenReturn(new SchemaAndSignatureCheckDto(false, null));
 
-                VCVerificationResultDto result = service.verifyV2(request);
+                VCVerificationResultDto result = service.verifyV2(request, false);
 
                 assertFalse(result.isAllChecksSuccessful());
                 assertFalse(result.getSchemaAndSignatureCheck().isValid());
@@ -309,7 +309,7 @@ public class VCVerificationServiceImplTest {
             CredentialVerificationSummary summary = mock(CredentialVerificationSummary.class);
             when(summary.getVerificationResult()).thenReturn(verificationResult);
             when(summary.getCredentialStatus()).thenReturn(Map.of("revocation", statusResult));
-            when(mockCredentialsVerifier.verifyAndGetCredentialStatus(anyString(), any(CredentialFormat.class), anyList()))
+            when(mockCredentialsVerifier.verifyAndGetCredentialStatus(anyString(), any(CredentialFormat.class), anyList(), anyBoolean()))
                     .thenReturn(summary);
             try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
                 utilsMock.when(() -> Utils.getCredentialFormat(TEST_JSON_VC_STRING)).thenReturn(CredentialFormat.LDP_VC);
@@ -317,7 +317,7 @@ public class VCVerificationServiceImplTest {
                 utilsMock.when(() -> Utils.populateExpiryCheck(any())).thenReturn(new ExpiryCheckDto(true));
                 utilsMock.when(() -> Utils.getVcVerificationStatus(summary)).thenReturn(VerificationStatus.REVOKED);
                 utilsMock.when(() -> Utils.populateStatusCheckDtoList(summary.getCredentialStatus())).thenReturn(List.of(new StatusCheckDto("revocation", false, null)));
-                VCVerificationResultDto result = service.verifyV2(request);
+                VCVerificationResultDto result = service.verifyV2(request, false);
 
                 assertFalse(result.isAllChecksSuccessful(), "Overall check should fail");
                 assertTrue(result.getSchemaAndSignatureCheck().isValid(), "Schema check should be valid");
@@ -335,7 +335,7 @@ public class VCVerificationServiceImplTest {
 
             VerificationResult verificationResult = mock(VerificationResult.class);
             when(verificationResult.getVerificationStatus()).thenReturn(true);
-            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class))).thenReturn(verificationResult);
+            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class), anyBoolean())).thenReturn(verificationResult);
 
             try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
                 utilsMock.when(() -> Utils.getCredentialFormat(anyString())).thenReturn(CredentialFormat.LDP_VC);
@@ -344,7 +344,7 @@ public class VCVerificationServiceImplTest {
                 utilsMock.when(() -> Utils.populateAllChecksSuccessful(any(), any(), any(), any())).thenCallRealMethod();
                 utilsMock.when(() -> Utils.extractClaims(anyString(), any(), any(),any())).thenReturn(expectedClaims);
 
-                VCVerificationResultDto result = service.verifyV2(request);
+                VCVerificationResultDto result = service.verifyV2(request, false);
 
                 assertFalse(result.getClaims().isEmpty());
                 assertEquals(9876543210L, result.getClaims().get("VID"));
@@ -360,7 +360,7 @@ public class VCVerificationServiceImplTest {
 
             VerificationResult verificationResult = mock(VerificationResult.class);
             when(verificationResult.getVerificationStatus()).thenReturn(true);
-            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class)))
+            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class), anyBoolean()))
                     .thenReturn(verificationResult);
 
             try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
@@ -369,7 +369,7 @@ public class VCVerificationServiceImplTest {
                 utilsMock.when(() -> Utils.populateExpiryCheck(any())).thenReturn(new ExpiryCheckDto(true));
                 utilsMock.when(() -> Utils.extractClaims(anyString(), any(), any(),any())).thenReturn(expectedClaims);
 
-                VCVerificationResultDto result = service.verifyV2(request);
+                VCVerificationResultDto result = service.verifyV2(request, false);
 
                 assertFalse(result.getClaims().isEmpty());
             }
@@ -383,13 +383,13 @@ public class VCVerificationServiceImplTest {
 
             VerificationResult verificationResult = mock(VerificationResult.class);
             when(verificationResult.getVerificationStatus()).thenReturn(true);
-            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class))).thenReturn(verificationResult);
+            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class), anyBoolean())).thenReturn(verificationResult);
 
             try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
                 utilsMock.when(() -> Utils.getCredentialFormat(TEST_JSON_VC_STRING)).thenReturn(CredentialFormat.LDP_VC);
                 utilsMock.when(() -> Utils.populateSchemaAndSignature(any())).thenReturn(new SchemaAndSignatureCheckDto(true, null));
 
-                VCVerificationResultDto result = service.verifyV2(request);
+                VCVerificationResultDto result = service.verifyV2(request, false);
 
                 assertTrue(result.getClaims().isEmpty());
             }
@@ -406,7 +406,7 @@ public class VCVerificationServiceImplTest {
 
             VerificationResult verificationResult = mock(VerificationResult.class);
             when(verificationResult.getVerificationStatus()).thenReturn(true);
-            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class)))
+            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class), anyBoolean()))
                     .thenReturn(verificationResult);
 
             try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
@@ -427,7 +427,7 @@ public class VCVerificationServiceImplTest {
                                 Utils.extractClaims(anyString(), any(), any(), any()))
                         .thenReturn(expectedClaims);
 
-                VCVerificationResultDto result = service.verifyV2(request);
+                VCVerificationResultDto result = service.verifyV2(request, false);
 
                 assertFalse(result.getClaims().isEmpty());
                 assertEquals(9876543210L, result.getClaims().get("VID"));
@@ -443,7 +443,7 @@ public class VCVerificationServiceImplTest {
 
             VerificationResult verificationResult = mock(VerificationResult.class);
             when(verificationResult.getVerificationStatus()).thenReturn(true);
-            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class)))
+            when(mockCredentialsVerifier.verify(anyString(), any(CredentialFormat.class), anyBoolean()))
                     .thenReturn(verificationResult);
 
             try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
@@ -454,7 +454,7 @@ public class VCVerificationServiceImplTest {
                 utilsMock.when(() -> Utils.populateSchemaAndSignature(any()))
                         .thenReturn(new SchemaAndSignatureCheckDto(true, null));
 
-                VCVerificationResultDto result = service.verifyV2(request);
+                VCVerificationResultDto result = service.verifyV2(request, false);
 
                 assertTrue(result.getClaims().isEmpty());
             }

--- a/verify-service/src/test/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImplTest.java
+++ b/verify-service/src/test/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImplTest.java
@@ -661,7 +661,7 @@ public class VerifiablePresentationSubmissionServiceImplTest {
             when(summary.getVerificationResult()).thenReturn(vResult);
             when(vResult.getVerificationStatus()).thenReturn(true);
 
-            when(credentialsVerifier.verifyAndGetCredentialStatus(anyString(), any(), anyList()))
+            when(credentialsVerifier.verifyAndGetCredentialStatus(anyString(), any(), anyList(), anyBoolean()))
                     .thenReturn(summary);
 
             assertDoesNotThrow(() -> verifiablePresentationSubmissionService.getVPResult(List.of("id"), "tx"));
@@ -733,7 +733,7 @@ public class VerifiablePresentationSubmissionServiceImplTest {
             AuthorizationRequestCreateResponse authResponse = new AuthorizationRequestCreateResponse(
                     "state123", transactionId, authDetails, System.currentTimeMillis() + 100000);
 
-            when(credentialsVerifier.verifyAndGetCredentialStatus(anyString(), eq(io.mosip.vercred.vcverifier.constants.CredentialFormat.LDP_VC), anyList()))
+            when(credentialsVerifier.verifyAndGetCredentialStatus(anyString(), eq(io.mosip.vercred.vcverifier.constants.CredentialFormat.LDP_VC), anyList(), anyBoolean()))
                     .thenReturn(mockSummary);
             when(verifiablePresentationRequestService.getLatestAuthorizationRequestFor(transactionId))
                     .thenReturn(authResponse);
@@ -783,7 +783,7 @@ public class VerifiablePresentationSubmissionServiceImplTest {
             AuthorizationRequestCreateResponse authResponse = new AuthorizationRequestCreateResponse(
                     "state123", transactionId, authDetails, System.currentTimeMillis() + 100000);
 
-            when(credentialsVerifier.verifyAndGetCredentialStatus(anyString(), eq(io.mosip.vercred.vcverifier.constants.CredentialFormat.DC_SD_JWT), anyList()))
+            when(credentialsVerifier.verifyAndGetCredentialStatus(anyString(), eq(io.mosip.vercred.vcverifier.constants.CredentialFormat.DC_SD_JWT), anyList(), anyBoolean()))
                     .thenReturn(mockSummary);
             when(verifiablePresentationRequestService.getLatestAuthorizationRequestFor(transactionId))
                     .thenReturn(authResponse);
@@ -1662,12 +1662,12 @@ public class VerifiablePresentationSubmissionServiceImplTest {
             mockResult.setAllChecksSuccessful(true);
             mockResult.setSchemaAndSignatureCheck(new SchemaAndSignatureCheckDto(true, null));
 
-            when(vcVerificationService.verifyV2(any(VCVerificationRequestDto.class))).thenReturn(mockResult);
+            when(vcVerificationService.verifyV2(any(VCVerificationRequestDto.class), anyBoolean())).thenReturn(mockResult);
 
             CredentialResultsDto results = ReflectionTestUtils.invokeMethod(
                     verifiablePresentationSubmissionService,
                     "verifyAndGetCredentialStatusV2",
-                    request, vcData, false);
+                    request, vcData, false, false);
 
             assertNotNull(results);
             assertNull(results.getHolderProofCheck(), "HolderProof should be null for non-SD-JWT");
@@ -1681,12 +1681,12 @@ public class VerifiablePresentationSubmissionServiceImplTest {
             VCVerificationResultDto mockResult = new VCVerificationResultDto();
             mockResult.setSchemaAndSignatureCheck(new SchemaAndSignatureCheckDto(true, null));
 
-            when(vcVerificationService.verifyV2(any(VCVerificationRequestDto.class))).thenReturn(mockResult);
+            when(vcVerificationService.verifyV2(any(VCVerificationRequestDto.class), anyBoolean())).thenReturn(mockResult);
 
             CredentialResultsDto results = ReflectionTestUtils.invokeMethod(
                     verifiablePresentationSubmissionService,
                     "verifyAndGetCredentialStatusV2",
-                    request, "sd-jwt-content", true);
+                    request, "sd-jwt-content", true, true);
 
             assertNotNull(results);
             assertTrue(results.getHolderProofCheck().isValid());
@@ -1704,12 +1704,12 @@ public class VerifiablePresentationSubmissionServiceImplTest {
             VCVerificationResultDto mockResult = new VCVerificationResultDto();
             mockResult.setSchemaAndSignatureCheck(signatureCheck);
 
-            when(vcVerificationService.verifyV2(any(VCVerificationRequestDto.class))).thenReturn(mockResult);
+            when(vcVerificationService.verifyV2(any(VCVerificationRequestDto.class), anyBoolean())).thenReturn(mockResult);
 
             CredentialResultsDto results = ReflectionTestUtils.invokeMethod(
                     verifiablePresentationSubmissionService,
                     "verifyAndGetCredentialStatusV2",
-                    request, "sd-jwt-content", true);
+                    request, "sd-jwt-content", true, true);
 
             assertNotNull(results);
             assertNotNull(results.getHolderProofCheck(), "HolderProofCheck should not be null if the error code matched an enum");
@@ -1862,6 +1862,108 @@ public class VerifiablePresentationSubmissionServiceImplTest {
             assertNotNull(result);
             assertTrue(result.getSdJwtTokens().containsKey("cred1"));
             assertEquals(1, result.getSdJwtTokens().get("cred1").size());
+        }
+    }
+
+    @Nested
+    class ProcessSdJwtClientIdAndNonce {
+
+        private static final String EXPECTED_NONCE = "test-nonce-value";
+        private static final String EXPECTED_CLIENT_ID = "https://verifier.example.com";
+
+        private static String b64(String json) {
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(json.getBytes());
+        }
+
+        private static final String CRED_HEADER = b64("{\"typ\":\"dc+sd-jwt\"}");
+        private static final String CRED_PAYLOAD = b64("{\"sub\":\"123\",\"cnf\":{\"kid\":\"k1\"}}");
+        private static final String CRED_SIG = b64("sig");
+        private static final String KB_HEADER = b64("{\"typ\":\"kb+jwt\"}");
+        private static final String KB_SIG = b64("kbsig");
+
+        private static final String SD_JWT_VALID_KB =
+                CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
+                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\"}") + "." + KB_SIG;
+
+        private static final String SD_JWT_WRONG_NONCE =
+                CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
+                + KB_HEADER + "." + b64("{\"nonce\":\"wrong-nonce\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\"}") + "." + KB_SIG;
+
+        private static final String SD_JWT_WRONG_AUD =
+                CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
+                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"https://wrong.example.com\"}") + "." + KB_SIG;
+
+        /** SD-JWT without a KB-JWT (trailing ~ only — KB-JWT payload will be undecodable). */
+        private static final String SD_JWT_NO_KB =
+                CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~";
+
+        /** Builds an auth request with require_cryptographic_holder_binding=true for "cred1". */
+        private AuthorizationRequestResponseDto buildAuthRequest() {
+            DCQLQueryDto dcql = new DCQLQueryDto(
+                    List.of(new CredentialQueryDto(
+                            "cred1", "dc+sd-jwt",
+                            new CredentialMetaDto(List.of("cred1"), null),
+                            true, false, null, null)),
+                    null);
+            return new AuthorizationRequestResponseDto(EXPECTED_CLIENT_ID, dcql, null, EXPECTED_NONCE, "responseUri", false, false);
+        }
+
+        private Map<String, List<String>> tokens(String sdJwt) {
+            Map<String, List<String>> map = new HashMap<>();
+            map.put("cred1", List.of(sdJwt));
+            return map;
+        }
+
+        @Test
+        void shouldReturnNull_whenKbJwtHasValidNonceAndAud() {
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtClientIdAndNonce(buildAuthRequest(), tokens(SD_JWT_VALID_KB));
+            assertNull(result);
+        }
+
+        @Test
+        void shouldReturnNull_whenSdJwtTokensMapIsEmpty() {
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtClientIdAndNonce(buildAuthRequest(), new HashMap<>());
+            assertNull(result);
+        }
+
+        @Test
+        void shouldReturnClientIdValidationFailed_whenKbJwtAudMismatch() {
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtClientIdAndNonce(buildAuthRequest(), tokens(SD_JWT_WRONG_AUD));
+            assertEquals(ErrorCode.CLIENT_ID_VALIDATION_FAILED, result);
+        }
+
+        @Test
+        void shouldReturnClientIdValidationFailed_whenKbJwtIsAbsent() {
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtClientIdAndNonce(buildAuthRequest(), tokens(SD_JWT_NO_KB));
+            assertEquals(ErrorCode.CLIENT_ID_VALIDATION_FAILED, result);
+        }
+
+        @Test
+        void shouldReturnNonceValidationFailed_whenKbJwtNonceMismatch() {
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtClientIdAndNonce(buildAuthRequest(), tokens(SD_JWT_WRONG_NONCE));
+            assertEquals(ErrorCode.NONCE_VALIDATION_FAILED, result);
+        }
+
+        @Test
+        void shouldReturnNull_whenHolderBindingNotRequired() {
+            DCQLQueryDto dcql = new DCQLQueryDto(
+                    List.of(new CredentialQueryDto(
+                            "cred1", "dc+sd-jwt",
+                            new CredentialMetaDto(List.of("cred1"), null),
+                            false, false, null, null)),
+                    null);
+            AuthorizationRequestResponseDto authRequest = new AuthorizationRequestResponseDto(
+                    EXPECTED_CLIENT_ID, dcql, null, EXPECTED_NONCE, "responseUri", false, false);
+
+            // Even a token with wrong aud/nonce passes when binding is not required
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtClientIdAndNonce(authRequest, tokens(SD_JWT_WRONG_AUD));
+            assertNull(result);
         }
     }
 }


### PR DESCRIPTION
- #2043 added clientId & nonce validation for sd-jwt

- added extracting actual root cause when `presentationVerifier` gives runtime exception
 
- #1988 integration with `verify() and verifyAndGetCredentialStatus()`  in `credentialVerifier` by passing `validateKeyBindingJwt` based on `require_cryptographic_holder_binding`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VP verification errors now return clearer failure details by surfacing the underlying root cause in the response.
  * Improved exception handling to preserve the original error cause.

* **New Features**
  * Expanded VP submission validation to support SD-JWT/KB-JWT tokens in addition to LDP tokens, returning specific `400 BAD_REQUEST` errors for client_id/nonce issues.
  * Updated VC verification to align key-binding/holder-binding validation behavior for plain VC verification flows.

* **Tests**
  * Updated and extended automated coverage for the new VP client_id/nonce validation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->