### PR TITLE
#2062 fixed race condition, fixed reliability bug, #1935 updated claims matching for non SD

### DIFF
--- a/verify-service/src/main/java/io/inji/verify/controller/VPSubmissionController.java
+++ b/verify-service/src/main/java/io/inji/verify/controller/VPSubmissionController.java
@@ -192,7 +192,9 @@ public class VPSubmissionController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(new ErrorDto(ErrorCode.VP_ALREADY_SUBMITTED));
         }
-        // --- 10. Return success response with redirect URI if generated
+        // ---- 10. Notify status listeners after transaction commits so the DB record is visible
+        verifiablePresentationRequestService.invokeVpRequestStatusListener(state);
+        // --- 11. Return success response with redirect URI if generated
         return ResponseEntity.status(HttpStatus.OK).body(response);
 
     }

--- a/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImpl.java
+++ b/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImpl.java
@@ -355,9 +355,8 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
     }
   
     /**
-     * This method is used to persist the VP submission details along with the response code and 
-     * its expiry time. 
-     * It also invokes the listener to update the status of VP request.
+     * This method is used to persist the VP submission details along with the response code and
+     * its expiry time.
      */
 	@Transactional
 	public void submitVpToken(AuthorizationRequestResponseDto authRequest, String vpToken, String state, String error,
@@ -374,9 +373,6 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
 			throw new VPAlreadySubmittedException("VP already submitted for request_id: " + state, e);
 		}
         log.debug("VP submission saved successfully for state: {}", state);
-        //log.debug(vpSubmissionRepository.getById(state).getVpToken());
-        /// invoke listener to update the status of VP request
-		verifiablePresentationRequestService.invokeVpRequestStatusListener(state);
 
 	}
 

--- a/verify-service/src/main/java/io/inji/verify/utils/Utils.java
+++ b/verify-service/src/main/java/io/inji/verify/utils/Utils.java
@@ -379,7 +379,7 @@ public final class Utils {
     }
 
     /** Returns all claims from an SD-JWT (payload + disclosures decoded), minus any meta claims. */
-    private static Map<String, Object> extractSdJwtClaims(String verifiableCredential, List<String> metaClaims) {
+    public static Map<String, Object> extractSdJwtClaims(String verifiableCredential, List<String> metaClaims) {
         try {
             SDJWT sdjwt = SDJWT.parse(verifiableCredential);
             String payloadJson = decodeBase64Json(sdjwt.getCredentialJwt().split("\\.")[1]);

--- a/verify-service/src/main/java/io/inji/verify/validator/DcqlValidator.java
+++ b/verify-service/src/main/java/io/inji/verify/validator/DcqlValidator.java
@@ -9,8 +9,6 @@ import io.inji.verify.shared.Constants;
 import io.inji.verify.utils.Utils;
 import org.springframework.stereotype.Component;
 
-import com.authlete.sd.Disclosure;
-import com.authlete.sd.SDJWT;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.net.URI;
@@ -645,18 +643,13 @@ public class DcqlValidator {
         }
     }
 
-    /** Returns only the selectively disclosed claims from an SD-JWT directly as a JsonNode. */
+    /** Returns all claims from an SD-JWT (payload non-SD claims + selectively disclosed claims) as a JsonNode. */
     private static JsonNode sdJwtDisclosedClaimsAsJson(String sdJwt) {
         try {
-            List<Disclosure> disclosures = SDJWT.parse(sdJwt).getDisclosures();
+            Map<String, Object> allClaims = Utils.extractSdJwtClaims(sdJwt, null);
             ObjectNode result = MAPPER.createObjectNode();
-            if (disclosures == null) {
-                return result;
-            }
-            for (Disclosure d : disclosures) {
-                if (d.getClaimName() != null) {
-                    result.set(d.getClaimName(), claimValueToJsonNode(d.getClaimValue()));
-                }
+            for (Map.Entry<String, Object> entry : allClaims.entrySet()) {
+                result.set(entry.getKey(), claimValueToJsonNode(entry.getValue()));
             }
             return result;
         } catch (VPRequestValidationException e) {

--- a/verify-service/src/main/java/io/inji/verify/validator/DcqlValidator.java
+++ b/verify-service/src/main/java/io/inji/verify/validator/DcqlValidator.java
@@ -171,7 +171,7 @@ public class DcqlValidator {
                     continue;
                 }
                 if (element instanceof Integer || element instanceof Long) {
-                    long value = element instanceof Integer ? (Integer) element : (Long) element;
+                    long value = ((Number) element).longValue();
                     if (value < 0 || value > Integer.MAX_VALUE) {
                         throw new VPRequestValidationException(ErrorCode.DCQL_CLAIM_PATH_INVALID);
                     }

--- a/verify-service/src/test/java/io/inji/verify/validator/DcqlVpTokenValidatorTest.java
+++ b/verify-service/src/test/java/io/inji/verify/validator/DcqlVpTokenValidatorTest.java
@@ -1437,10 +1437,17 @@ class DcqlVpTokenValidatorTest {
             ".eyJfc2RfYWxnIjoic2hhLTI1NiIsIl9zZCI6WyJxQ2NEbUZOZmpCSTZDRnhpbFhPY3VKQkV6RXA3OUdBWWdsODNrRHNfU3E0Il19" +
             ".sig~WyJzYWx0NSIsInNjb3JlIiw0Ml0~";
 
-    // No disclosures — payload has iss=mandatory_issuer baked in, no _sd claims
+    // No disclosures — payload is {"_sd_alg":"sha-256","_sd":[]}, no regular claims and no selectively disclosed claims
     private static final String SD_JWT_NO_DISCLOSURES =
             "eyJhbGciOiJFUzI1NiIsInR5cCI6ImRjK3NkLWp3dCJ9" +
             ".eyJfc2RfYWxnIjoic2hhLTI1NiIsIl9zZCI6W119" +
+            ".sig~";
+
+    // Non-SD payload claim — payload is {"iss":"https://issuer.example","_sd_alg":"sha-256","_sd":[]}, no disclosures
+    // "iss" is a regular (non-selectively-disclosed) JWT payload claim
+    private static final String SD_JWT_ISS_ONLY =
+            "eyJhbGciOiJFUzI1NiIsInR5cCI6ImRjK3NkLWp3dCJ9" +
+            ".eyJpc3MiOiJodHRwczovL2lzc3Vlci5leGFtcGxlIiwiX3NkX2FsZyI6InNoYS0yNTYiLCJfc2QiOltdfQ" +
             ".sig~";
 
     // dc+sd-jwt with {"name": "Alice"} disclosure
@@ -1594,9 +1601,9 @@ class DcqlVpTokenValidatorTest {
     }
 
     @Test
-    void shouldFail_whenRequestedClaimIsInPayloadButNotDisclosed() {
-        // SD_JWT_NO_DISCLOSURES has no ~disclosure~ parts, so no selectively disclosed claims.
-        // Even if "name" were baked into the payload, DCQL claims check only disclosed claims.
+    void shouldFail_whenClaimAbsentFromBothPayloadAndDisclosures() {
+        // SD_JWT_NO_DISCLOSURES payload is {"_sd_alg":"sha-256","_sd":[]} — "name" is absent
+        // from both the JWT payload and the selective disclosures, so validation must fail.
         List<ClaimQueryDto> claims = List.of(claimPath("name"));
         DCQLQueryDto query = new DCQLQueryDto(
                 List.of(sdJwtCredentialQueryWithClaims("cred1", claims)), null);
@@ -1606,6 +1613,43 @@ class DcqlVpTokenValidatorTest {
                         sdJwtToken("cred1", SD_JWT_NO_DISCLOSURES)));
 
         assertEquals(ErrorCode.VP_TOKEN_CLAIM_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    void shouldPass_whenNonSdPayloadClaimMatchesQuery() {
+        // SD_JWT_ISS_ONLY has "iss" as a regular (non-selectively-disclosed) JWT payload claim.
+        // Claim matching now covers both SD disclosures and regular payload claims, so "iss" must be found.
+        List<ClaimQueryDto> claims = List.of(claimPath("iss"));
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(sdJwtCredentialQueryWithClaims("cred1", claims)), null);
+
+        assertDoesNotThrow(() -> validator.validateVpTokenAgainstDcql(query,
+                sdJwtToken("cred1", SD_JWT_ISS_ONLY)));
+    }
+
+    @Test
+    void shouldPass_whenNonSdPayloadClaimValueMatchesQuery() {
+        // "iss" is a regular payload claim with value "https://issuer.example" — value match must succeed.
+        List<ClaimQueryDto> claims = List.of(claimPathWithValues(List.of("https://issuer.example"), "iss"));
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(sdJwtCredentialQueryWithClaims("cred1", claims)), null);
+
+        assertDoesNotThrow(() -> validator.validateVpTokenAgainstDcql(query,
+                sdJwtToken("cred1", SD_JWT_ISS_ONLY)));
+    }
+
+    @Test
+    void shouldFail_whenNonSdPayloadClaimValueMismatch() {
+        // "iss" is present but value doesn't match the declared constraint.
+        List<ClaimQueryDto> claims = List.of(claimPathWithValues(List.of("https://other.example"), "iss"));
+        DCQLQueryDto query = new DCQLQueryDto(
+                List.of(sdJwtCredentialQueryWithClaims("cred1", claims)), null);
+
+        VPRequestValidationException ex = assertThrows(VPRequestValidationException.class,
+                () -> validator.validateVpTokenAgainstDcql(query,
+                        sdJwtToken("cred1", SD_JWT_ISS_ONLY)));
+
+        assertEquals(ErrorCode.VP_TOKEN_CLAIM_VALUE_MISMATCH, ex.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
#2062 fixed possible race condition in VP submission
#1935 updated claims matching logic with non SD and SD both
fixed sonar reliability bug for Verify Service


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SD-JWT validation to properly handle all credential claims, including non-selectively-disclosed claims from the payload.
  * Enhanced DCQL path validation for numeric path elements.
  * VP submission now includes a post-submission status notification step.

* **Tests**
  * Expanded SD-JWT validation test coverage with additional scenarios for claim resolution and payload claim handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->