### PR TITLE
#1961 fixed gaps in documentation to support both dc+sd-jwt and vc+sd-jwt

### DIFF
--- a/docs/OpenID4VPCrossDeviceFlow.md
+++ b/docs/OpenID4VPCrossDeviceFlow.md
@@ -7,7 +7,7 @@ The implementation adheres to the OpenID4VP [specification](https://openid.net/s
 ## Specifications supported
 - OpenID for Verifiable Presentations – [Draft 23 🔗](https://openid.net/specs/openid-4-verifiable-presentations-1_0-23.html).
 - Presentation Exchange 2.0.0 [specification 🔗](https://identity.foundation/presentation-exchange/spec/v2.0.0)
-- Supported VC format: LDP VC, SD-JWT VC, CWT VC
+- Supported VC format: LDP VC, SD-JWT VC (`dc+sd-jwt` draft-10 and `vc+sd-jwt` draft-04), CWT VC
 
 ## API Documentation
 API documentation is available in the [Inji Verify API documentation 🔗](https://mosip.stoplight.io/docs/inji-verify/branches/main/).

--- a/docs/SD-JWT-Support.md
+++ b/docs/SD-JWT-Support.md
@@ -2,7 +2,7 @@
 
 ## 🔍 Overview
 
-Inji Verify now supports **Selective Disclosure JSON Web Tokens (SD-JWTs)** as a credential format — specifically, the IETF-defined SD-JWT (vc+sd-jwt) format.  
+Inji Verify now supports **Selective Disclosure JSON Web Tokens (SD-JWTs)** as a credential format — both the legacy `vc+sd-jwt` format (SD-JWT VC draft-04) and the current `dc+sd-jwt` format (SD-JWT VC draft-10).  
 When Verifiable Credentials (VCs) are returned as SD-JWT strings, the UI decodes and renders them using the `@sd-jwt/decode` library.
 
 This document explains:
@@ -18,7 +18,8 @@ This document explains:
 It enables privacy-preserving presentations without revealing undisclosed claims.
 
 Key characteristics:
-- VCs are encoded as **compact SD-JWT strings (vc+sd-jwt)** 
+- VCs are encoded as **compact SD-JWT strings** — either `dc+sd-jwt` (current, draft-10) or `vc+sd-jwt` (legacy, draft-04)
+- Both formats are recognized and processed identically; `vc+sd-jwt` is accepted for backward compatibility with older credentials
 - Public and disclosed claims are included in the Verifiable Presentation
 - Undisclosed claims remain hidden while maintaining cryptographic binding
 - Signature integrity is maintained

--- a/docs/api-documentation-openapi.yaml
+++ b/docs/api-documentation-openapi.yaml
@@ -920,10 +920,10 @@ paths:
 
         **Version-specific behavior:**
 
-        From `0.15.x` onwards, 
+        From `0.15.x` onwards,
         - This endpoint supports verification of both JSON-LD and SD-JWT formatted VCs.
         - To verify a JSON-LD VC, set the request header: `Content-Type: application/vc+ld+json`
-        - To verify an SD-JWT VC, set the request header: `Content-Type: application/vc+sd-jwt`
+        - To verify an SD-JWT VC, set the request header: `Content-Type: application/dc+sd-jwt` (current format, draft-10) or `Content-Type: application/vc+sd-jwt` (legacy format, draft-04)
 
         From `0.16.x` onwards, 
         - This endpoint also performs revocation checks for JSON-LD credentials. 
@@ -964,12 +964,20 @@ paths:
                       verificationMethod: 'did:web:example.com#key-1'
                       proofPurpose: assertionMethod
                       jws: eyJhbGciOiJFZERTQSJ9.eyJpYXQiOiIwMjMxMTIzMTIzMTMiLCJ...signature
+          application/dc+sd-jwt:
+            schema:
+              $ref: '#/components/schemas/VCVerificationSDJWTRequest'
+            examples:
+              example:
+                summary: Example dc+sd-jwt format VC to be verified (current, draft-10)
+                value:
+                  vc: eyJhbGciOiJFZERTQSIsInR5cCI6ImRjK3NkLWp3dCJ9.eyJ2Y3QiOiJodHRwczovL2V4YW1wbGUuY29tL015Q3JlZGVudGlhbCJ9...signature
           application/vc+sd-jwt:
             schema:
               $ref: '#/components/schemas/VCVerificationSDJWTRequest'
             examples:
               example:
-                summary: Example SD-JWT format VC to be verified
+                summary: Example vc+sd-jwt format VC to be verified (legacy, draft-04)
                 value:
                   vc: eyJhbGciOiJFZERTQSJ9.eyJpYXQiOiIwMjMxMTIzMTIzMTMiLCJ...signature
           application/vc+cwt:

--- a/docs/api-documentation-openapi.yaml
+++ b/docs/api-documentation-openapi.yaml
@@ -966,20 +966,12 @@ paths:
                       jws: eyJhbGciOiJFZERTQSJ9.eyJpYXQiOiIwMjMxMTIzMTIzMTMiLCJ...signature
           application/dc+sd-jwt:
             schema:
-              $ref: '#/components/schemas/VCVerificationSDJWTRequest'
-            examples:
-              example:
-                summary: Example dc+sd-jwt format VC to be verified (current, draft-10)
-                value:
-                  vc: eyJhbGciOiJFZERTQSIsInR5cCI6ImRjK3NkLWp3dCJ9.eyJ2Y3QiOiJodHRwczovL2V4YW1wbGUuY29tL015Q3JlZGVudGlhbCJ9...signature
+              type: string
+            example: eyJhbGciOiJFZERTQSIsInR5cCI6ImRjK3NkLWp3dCJ9.eyJ2Y3QiOiJodHRwczovL2V4YW1wbGUuY29tL015Q3JlZGVudGlhbCJ9...signature
           application/vc+sd-jwt:
             schema:
-              $ref: '#/components/schemas/VCVerificationSDJWTRequest'
-            examples:
-              example:
-                summary: Example vc+sd-jwt format VC to be verified (legacy, draft-04)
-                value:
-                  vc: eyJhbGciOiJFZERTQSJ9.eyJpYXQiOiIwMjMxMTIzMTIzMTMiLCJ...signature
+              type: string
+            example: eyJhbGciOiJFZERTQSJ9.eyJpYXQiOiIwMjMxMTIzMTIzMTMiLCJ...signature
           application/vc+cwt:
             schema:
               $ref: '#/components/schemas/VCVerificationCWTRequest'

--- a/verify-service/src/main/java/io/inji/verify/services/impl/VCVerificationServiceImpl.java
+++ b/verify-service/src/main/java/io/inji/verify/services/impl/VCVerificationServiceImpl.java
@@ -47,7 +47,7 @@ public class VCVerificationServiceImpl implements VCVerificationService {
     public VCVerificationStatusDto verify(String vc, String contentType) throws CredentialStatusCheckException {
         CredentialFormat format;
         if ("application/vc+sd-jwt".equalsIgnoreCase(contentType) || "application/dc+sd-jwt".equalsIgnoreCase(contentType)) {
-            format = CredentialFormat.VC_SD_JWT;
+            format = CredentialFormat.DC_SD_JWT;
         } else if ("application/vc+cwt".equalsIgnoreCase(contentType)) {
             format = CredentialFormat.CWT_VC;
         } else {

--- a/verify-service/src/main/java/io/inji/verify/services/impl/VCVerificationServiceImpl.java
+++ b/verify-service/src/main/java/io/inji/verify/services/impl/VCVerificationServiceImpl.java
@@ -46,8 +46,10 @@ public class VCVerificationServiceImpl implements VCVerificationService {
     @Override
     public VCVerificationStatusDto verify(String vc, String contentType) throws CredentialStatusCheckException {
         CredentialFormat format;
-        if ("application/vc+sd-jwt".equalsIgnoreCase(contentType) || "application/dc+sd-jwt".equalsIgnoreCase(contentType)) {
+        if ("application/dc+sd-jwt".equalsIgnoreCase(contentType)) {
             format = CredentialFormat.DC_SD_JWT;
+        } else if ("application/vc+sd-jwt".equalsIgnoreCase(contentType)) {
+            format = CredentialFormat.VC_SD_JWT;
         } else if ("application/vc+cwt".equalsIgnoreCase(contentType)) {
             format = CredentialFormat.CWT_VC;
         } else {


### PR DESCRIPTION
…-jwt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SD-JWT support documentation to reflect support for both the current (`dc+sd-jwt` draft-10) and legacy (`vc+sd-jwt` draft-04) formats with backward compatibility.

* **API Updates**
  * Expanded `/vc-verification` endpoint documentation to support both SD-JWT format options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->