### PR TITLE
#2086 removed hardcoding of servlet context path

### DIFF
--- a/docker-compose/docker-compose-ci.yaml
+++ b/docker-compose/docker-compose-ci.yaml
@@ -38,6 +38,7 @@ services:
       - INJI_KEYSTORE_FILE_PASS=mosip
       - INJI_VERIFY_REDIRECT_URI=http://verify-service:8080
       - INJI_VERIFY_CLAIMS_WITH_META_DATA=_sd,_sd_alg,iss,cnf,sub,aud,exp,nbf,iat,cti
+      - VERIFY_CONTEXT_PATH=/v1/verify
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - INJI_VERIFY_REDIRECT_URI=https://VERIFY_SERVICE_PROXY_FOR_LOCALHOST
       - INJI_VERIFY_RESPONSE_CODE_EXPIRY_TIME_IN_MINS=5
       - INJI_VERIFY_CLAIMS_WITH_META_DATA=_sd,_sd_alg,iss,cnf,sub,aud,exp,nbf,iat,cti
+      - VERIFY_CONTEXT_PATH=/v1/verify
     depends_on:
       - postgres
 

--- a/helm/inji-verify-service/templates/servicemonitor.yaml
+++ b/helm/inji-verify-service/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   endpoints:
     - targetPort: {{ .Values.springServicePort }}
-      path: {{ .Values.metrics.endpointPath }} 
+      path: {{ tpl .Values.metrics.endpointPath . }} 
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}

--- a/helm/inji-verify-service/templates/virtualservice.yaml
+++ b/helm/inji-verify-service/templates/virtualservice.yaml
@@ -19,7 +19,7 @@ spec:
   http:
   - match:
       - uri:
-          prefix: {{ .Values.istio.prefix }}
+          prefix: {{ tpl .Values.istio.prefix . }}
     route:
     - destination:
         host: {{ template "common.names.fullname" . }}

--- a/helm/inji-verify-service/values.yaml
+++ b/helm/inji-verify-service/values.yaml
@@ -66,6 +66,10 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## Context path for the verify service. Set this to /v1/verify for standalone deployments.
+## Leave empty (or do not set) when Verify is embedded as a library in another service (e.g. Certify).
+contextPath: /v1/verify
+
 ## Port on which this particular spring service module is running.
 springServicePort: 8080
 
@@ -75,7 +79,7 @@ springServicePort: 8080
 startupProbe:
   enabled: true
   httpGet:
-    path: /v1/verify/actuator/health
+    path: "{{ .Values.contextPath }}/actuator/health"
     port: 8080
   initialDelaySeconds: 0
   periodSeconds: 10
@@ -86,7 +90,7 @@ startupProbe:
 livenessProbe:
   enabled: true
   httpGet:
-    path: /v1/verify/actuator/health
+    path: "{{ .Values.contextPath }}/actuator/health"
     port: 8080
   initialDelaySeconds: 20
   periodSeconds: 10
@@ -97,7 +101,7 @@ livenessProbe:
 readinessProbe:
   enabled: true
   httpGet:
-    path: /v1/verify/actuator/health
+    path: "{{ .Values.contextPath }}/actuator/health"
     port: 8080
   initialDelaySeconds: 0
   periodSeconds: 10
@@ -241,6 +245,8 @@ updateStrategy:
 ##     value: "bar"
 ##
 extraEnvVars:
+  - name: VERIFY_CONTEXT_PATH
+    value: "{{ .Values.contextPath }}"
   - name: DATABASE_HOST
     valueFrom:
       configMapKeyRef:
@@ -393,7 +399,7 @@ metrics:
   podAnnotations:
     prometheus.io/scrape: "true"
 
-  endpointPath: /v1/verify/actuator/prometheus
+  endpointPath: "{{ .Values.contextPath }}/actuator/prometheus"
 
   ## Prometheus Service Monitor
   ## ref: https://github.com/coreos/prometheus-operator
@@ -445,4 +451,4 @@ istio:
   enabled: true
   gateways:
     - istio-system/internal
-  prefix: /v1/verify
+  prefix: "{{ .Values.contextPath }}"

--- a/verify-service/src/main/resources/application-local.properties
+++ b/verify-service/src/main/resources/application-local.properties
@@ -1,21 +1,23 @@
+verify.context-path=/v1/verify 
 spring.application.name=verify-service
-server.servlet.context-path=/v1/verify
-spring.jpa.properties.hibernate.default_schema=verify
+server.servlet.context-path=${verify.context-path:}
 
+#Local HSQL DB
 spring.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
 spring.sql.init.platform=hsqldb
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.default_schema=verify
 spring.datasource.url=jdbc:hsqldb:mem:testdb;
-
 spring.sql.init.mode=embedded
 spring.sql.init.schema-locations=classpath:schema-hsqldb.sql
 spring.sql.init.continue-on-error=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.HSQLDialect
+
 spring.jackson.deserialization.fail-on-unknown-properties=true
 
 # Below configuration are for cookie setup
 inji.verify.cookie-secure-value=${INJI_VERIFY_COOKIE_SECURE_VALUE:false}
-inji.verify.cookie-path=${INJI_VERIFY_COOKIE_PATH:/v1/verify}
+inji.verify.cookie-path=${INJI_VERIFY_COOKIE_PATH:${verify.context-path:/v1/verify}}
 inji.verify.cookie-duration-in-minute=${INJI_VERIFY_COOKIE_DURATION_IN_MINUTE:5}
 inji.verify.cookie-same-site=${INJI_VERIFY_COOKIE_SAME_SITE:Lax}
 

--- a/verify-service/src/main/resources/application-local.properties
+++ b/verify-service/src/main/resources/application-local.properties
@@ -1,4 +1,4 @@
-verify.context-path=/v1/verify 
+verify.context-path=/v1/verify
 spring.application.name=verify-service
 server.servlet.context-path=${verify.context-path:}
 

--- a/verify-service/src/main/resources/application.properties
+++ b/verify-service/src/main/resources/application.properties
@@ -1,16 +1,19 @@
 spring.application.name=verify-service
+server.servlet.context-path=${verify.context-path:}
+
+#DB configurations
 spring.datasource.driverClassName=org.postgresql.Driver
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=none
-server.servlet.context-path=/v1/verify
 spring.datasource.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?currentSchema=${DATABASE_SCHEMA}
 spring.datasource.username=${DATABASE_USERNAME}
 spring.datasource.password=${DATABASE_PASSWORD}
+
 spring.jackson.deserialization.fail-on-unknown-properties=true
 
 # Below configuration are for cookie setup
 inji.verify.cookie-secure-value=${INJI_VERIFY_COOKIE_SECURE_VALUE:true}
-inji.verify.cookie-path=${INJI_VERIFY_COOKIE_PATH:/v1/verify}
+inji.verify.cookie-path=${INJI_VERIFY_COOKIE_PATH:${verify.context-path:/v1/verify}}
 inji.verify.cookie-duration-in-minute=${INJI_VERIFY_COOKIE_DURATION_IN_MINUTE:5}
 inji.verify.cookie-same-site=${INJI_VERIFY_COOKIE_SAME_SITE:Lax}
 

--- a/verify-service/src/main/resources/bootstrap.properties
+++ b/verify-service/src/main/resources/bootstrap.properties
@@ -1,2 +1,2 @@
 spring.application.name=verify-service
-server.servlet.context-path=/v1/verify
+server.servlet.context-path=${verify.context-path:}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable context path for the service, allowing deployments to align routing, health checks, metrics, and cookies with custom base paths.
  * Updated Kubernetes and Istio configuration to support templated paths and prefixes in environment-specific values.

* **Bug Fixes**
  * Replaced several hardcoded `/v1/verify` paths with configurable values so probes, monitoring, and traffic routing stay consistent across environments.
  * Improved local and default configuration handling for cookie paths and servlet context paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->