### PR TITLE
#2041 fixed Dependabot CVEs for commons-lang3 in ui-test

### DIFF
--- a/ui-test/pom.xml
+++ b/ui-test/pom.xml
@@ -49,9 +49,19 @@
         <pdfbox.version>2.0.31</pdfbox.version>
         <browserstack.local.version>1.1.5</browserstack.local.version>
         <browserstack.sdk.version>1.31.1</browserstack.sdk.version>
-        <commons.lang.version>2.6</commons.lang.version>
+        <commons.lang3.version>3.18.0</commons.lang3.version>
         <aws.sdk.s3.version>1.12.794</aws.sdk.s3.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons.lang3.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Selenium -->
@@ -155,9 +165,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>${commons.lang.version}</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons.lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/ui-test/src/main/java/stepdefinitions/StepDefInjiWebWallet.java
+++ b/ui-test/src/main/java/stepdefinitions/StepDefInjiWebWallet.java
@@ -3,7 +3,7 @@ package stepdefinitions;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;


### PR DESCRIPTION
PR includes fix for #[75](https://github.com/inji/inji-verify/security/dependabot/75) commons-lang

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded the test modules to use Apache Commons Lang 3, including a direct switch to the newer library version.
* **Bug Fixes**
  * Updated exception handling imports to match the newer Commons Lang package.
  * Excluded a couple of unnecessary transitive dependencies from the shared test support library to keep test setups leaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->