### PR TITLE
#2013 added missing validations for "iat" in kb-jwt; Nonce entropy fix

### DIFF
--- a/verify-service/src/main/java/io/inji/verify/controller/VPSubmissionController.java
+++ b/verify-service/src/main/java/io/inji/verify/controller/VPSubmissionController.java
@@ -217,6 +217,12 @@ public class VPSubmissionController {
                 log.error("SD-JWT KB-JWT clientId/nonce validation failed: {}", error);
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorDto(error));
             }
+            ErrorCode iatError = verifiablePresentationSubmissionService
+                    .processSdJwtKbJwtIat(authRequest.getAuthorizationDetails(), sdJwtTokens);
+            if (iatError != null) {
+                log.error("SD-JWT KB-JWT iat validation failed: {}", iatError);
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorDto(iatError));
+            }
         }
         if (ldpVpTokens.isEmpty() && sdJwtTokens.isEmpty()) {
             log.debug("Skipping clientId/nonce validation as no bindable tokens extracted.");

--- a/verify-service/src/main/java/io/inji/verify/enums/ErrorCode.java
+++ b/verify-service/src/main/java/io/inji/verify/enums/ErrorCode.java
@@ -86,7 +86,9 @@ public enum ErrorCode {
     VP_TOKEN_SD_JWT_VCT_MISMATCH("invalid_request", "vp_token SD-JWT credential vct claim does not match any of the vct_values in the DCQL query."),
     VP_TOKEN_CLAIM_NOT_FOUND("invalid_request", "vp_token ldp_vc credential does not contain a required claim path declared in the DCQL query."),
     VP_TOKEN_CLAIM_VALUE_MISMATCH("invalid_request", "vp_token ldp_vc credential claim value does not match any of the declared values in the DCQL query."),
-    VP_TOKEN_CLAIM_SETS_NOT_SATISFIED("invalid_request", "vp_token credential does not satisfy any of the claim_sets options declared in the DCQL query.");
+    VP_TOKEN_CLAIM_SETS_NOT_SATISFIED("invalid_request", "vp_token credential does not satisfy any of the claim_sets options declared in the DCQL query."),
+    KB_JWT_IAT_MISSING_OR_INVALID("invalid_request", "KB-JWT iat claim is missing or invalid."),
+    KB_JWT_IAT_IN_FUTURE("invalid_request", "KB-JWT iat is in the future beyond the allowed clock skew.");
 
     private final String errorCode;
     private final String errorMessage;

--- a/verify-service/src/main/java/io/inji/verify/services/VerifiablePresentationSubmissionService.java
+++ b/verify-service/src/main/java/io/inji/verify/services/VerifiablePresentationSubmissionService.java
@@ -33,6 +33,8 @@ public interface VerifiablePresentationSubmissionService {
     ErrorCode processLdpVpClientIdAndNonce(AuthorizationRequestResponseDto authRequest, Map<String, List<JSONObject>> ldpVpTokens);
 
     ErrorCode processSdJwtClientIdAndNonce(AuthorizationRequestResponseDto authRequest, Map<String, List<String>> sdJwtTokens);
+
+    ErrorCode processSdJwtKbJwtIat(AuthorizationRequestResponseDto authRequest, Map<String, List<String>> sdJwtTokens);
     
     String generateResponseCode(AuthorizationRequestResponseDto authRequest);
     

--- a/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImpl.java
+++ b/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImpl.java
@@ -314,6 +314,44 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
     }
 
     /**
+     * Validates the KB-JWT {@code iat} claim for all SD-JWT tokens in a single pass.
+     * Checks that {@code iat} is present and not in the future beyond clock skew.
+     * No max-age check — per SD-JWT RFC 9901, {@code nonce} is the replay-protection
+     * mechanism; {@code iat} only needs to be a valid past/present timestamp.
+     * Only applies to query IDs where {@code require_cryptographic_holder_binding=true}.
+     * Returns the first {@link ErrorCode} encountered, or null if all tokens pass.
+     */
+    @Override
+    public ErrorCode processSdJwtKbJwtIat(AuthorizationRequestResponseDto authRequest, Map<String, List<String>> sdJwtTokens) {
+        final long clockSkewSeconds = 60L;
+        for (Map.Entry<String, List<String>> entry : sdJwtTokens.entrySet()) {
+            String queryId = entry.getKey();
+            if (!isCryptographicHolderBindingRequired(authRequest, queryId)) {
+                log.debug("Skipping KB-JWT iat validation for query ID {} since require_cryptographic_holder_binding is false", queryId);
+                continue;
+            }
+            for (String sdJwt : entry.getValue()) {
+                JSONObject kbPayload = Utils.extractKbJwtPayload(sdJwt);
+                if (kbPayload == null) {
+                    log.error("KB-JWT payload could not be decoded for iat check, query ID: {}", queryId);
+                    return ErrorCode.KB_JWT_IAT_MISSING_OR_INVALID;
+                }
+                long iat = kbPayload.optLong("iat", -1);
+                if (iat <= 0) {
+                    log.error("KB-JWT iat is missing or invalid for query ID: {}", queryId);
+                    return ErrorCode.KB_JWT_IAT_MISSING_OR_INVALID;
+                }
+                long nowSeconds = System.currentTimeMillis() / 1000;
+                if (iat > nowSeconds + clockSkewSeconds) {
+                    log.error("KB-JWT iat is in the future for query ID: {}, iat={}, now={}", queryId, iat, nowSeconds);
+                    return ErrorCode.KB_JWT_IAT_IN_FUTURE;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * This method generates a unique response code using UUID if the authorization request requires response code validation. If response code validation is not required, it returns null.
      * @param authRequest
      * @return

--- a/verify-service/src/main/java/io/inji/verify/utils/SecurityUtils.java
+++ b/verify-service/src/main/java/io/inji/verify/utils/SecurityUtils.java
@@ -15,7 +15,7 @@ public class SecurityUtils {
     private static final SecureRandom random = new SecureRandom();
 
     public static String generateNonce() {
-        byte[] randomBytes = new byte[16];
+        byte[] randomBytes = new byte[24];
         random.nextBytes(randomBytes);
         return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
     }

--- a/verify-service/src/test/java/io/inji/verify/controller/VPSubmissionControllerTest.java
+++ b/verify-service/src/test/java/io/inji/verify/controller/VPSubmissionControllerTest.java
@@ -577,11 +577,44 @@ class VPSubmissionControllerTest {
         when(auth.getAuthorizationDetails()).thenReturn(mock(AuthorizationRequestResponseDto.class));
 
         when(vpSubmissionService.processSdJwtClientIdAndNonce(any(), any())).thenReturn(null);
+        when(vpSubmissionService.processSdJwtKbJwtIat(any(), any())).thenReturn(null);
 
         ResponseEntity<?> response = controller.submitVP(VALID_VP_TOKEN, STATE, null, null, request);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         verify(vpSubmissionService).submitVpToken(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldReturnBadRequest_whenSdJwtKbJwtIatMissingOrInvalid() {
+        mockActiveAuth();
+
+        when(vpSubmissionService.processSdJwtClientIdAndNonce(any(), any())).thenReturn(null);
+        when(vpSubmissionService.processSdJwtKbJwtIat(any(), any()))
+                .thenReturn(ErrorCode.KB_JWT_IAT_MISSING_OR_INVALID);
+
+        ResponseEntity<?> response = controller.submitVP(VALID_VP_TOKEN, STATE, null, null, request);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        ErrorDto body = (ErrorDto) response.getBody();
+        assertNotNull(body);
+        assertEquals(ErrorCode.KB_JWT_IAT_MISSING_OR_INVALID.getErrorCode(), body.getErrorCode());
+    }
+
+    @Test
+    void shouldReturnBadRequest_whenSdJwtKbJwtIatInFuture() {
+        mockActiveAuth();
+
+        when(vpSubmissionService.processSdJwtClientIdAndNonce(any(), any())).thenReturn(null);
+        when(vpSubmissionService.processSdJwtKbJwtIat(any(), any()))
+                .thenReturn(ErrorCode.KB_JWT_IAT_IN_FUTURE);
+
+        ResponseEntity<?> response = controller.submitVP(VALID_VP_TOKEN, STATE, null, null, request);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        ErrorDto body = (ErrorDto) response.getBody();
+        assertNotNull(body);
+        assertEquals(ErrorCode.KB_JWT_IAT_IN_FUTURE.getErrorCode(), body.getErrorCode());
     }
 
     // ---- validateRequest missing paths ----

--- a/verify-service/src/test/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImplTest.java
+++ b/verify-service/src/test/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImplTest.java
@@ -2341,22 +2341,33 @@ public class VerifiablePresentationSubmissionServiceImplTest {
         private static final String CRED_SIG = b64("sig");
         private static final String KB_HEADER = b64("{\"typ\":\"kb+jwt\"}");
         private static final String KB_SIG = b64("kbsig");
+        private static final long NOW_SEC = System.currentTimeMillis() / 1000;
 
         private static final String SD_JWT_VALID_KB =
                 CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
-                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\"}") + "." + KB_SIG;
+                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\",\"iat\":" + NOW_SEC + "}") + "." + KB_SIG;
 
         private static final String SD_JWT_WRONG_NONCE =
                 CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
-                + KB_HEADER + "." + b64("{\"nonce\":\"wrong-nonce\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\"}") + "." + KB_SIG;
+                + KB_HEADER + "." + b64("{\"nonce\":\"wrong-nonce\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\",\"iat\":" + NOW_SEC + "}") + "." + KB_SIG;
 
         private static final String SD_JWT_WRONG_AUD =
                 CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
-                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"https://wrong.example.com\"}") + "." + KB_SIG;
+                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"https://wrong.example.com\",\"iat\":" + NOW_SEC + "}") + "." + KB_SIG;
 
         /** SD-JWT without a KB-JWT (trailing ~ only — KB-JWT payload will be undecodable). */
         private static final String SD_JWT_NO_KB =
                 CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~";
+
+        /** SD-JWT with KB-JWT missing the iat claim. */
+        private static final String SD_JWT_IAT_MISSING =
+                CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
+                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\"}") + "." + KB_SIG;
+
+        /** SD-JWT with KB-JWT iat 2 minutes in the future (beyond 60s clock skew). */
+        private static final String SD_JWT_IAT_IN_FUTURE =
+                CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
+                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\",\"iat\":" + (NOW_SEC + 120) + "}") + "." + KB_SIG;
 
         /** Builds an auth request with require_cryptographic_holder_binding=true for "cred1". */
         private AuthorizationRequestResponseDto buildAuthRequest() {
@@ -2424,6 +2435,107 @@ public class VerifiablePresentationSubmissionServiceImplTest {
             // Even a token with wrong aud/nonce passes when binding is not required
             ErrorCode result = verifiablePresentationSubmissionService
                     .processSdJwtClientIdAndNonce(authRequest, tokens(SD_JWT_WRONG_AUD));
+            assertNull(result);
+        }
+    }
+
+    @Nested
+    class ProcessSdJwtKbJwtIat {
+
+        private static final String EXPECTED_NONCE = "test-nonce-value";
+        private static final String EXPECTED_CLIENT_ID = "https://verifier.example.com";
+
+        private static String b64(String json) {
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(json.getBytes());
+        }
+
+        private static final String CRED_HEADER = b64("{\"typ\":\"dc+sd-jwt\"}");
+        private static final String CRED_PAYLOAD = b64("{\"sub\":\"123\",\"cnf\":{\"kid\":\"k1\"}}");
+        private static final String CRED_SIG = b64("sig");
+        private static final String KB_HEADER = b64("{\"typ\":\"kb+jwt\"}");
+        private static final String KB_SIG = b64("kbsig");
+        private static final long NOW_SEC = System.currentTimeMillis() / 1000;
+
+        private static final String SD_JWT_VALID_IAT =
+                CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
+                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\",\"iat\":" + NOW_SEC + "}") + "." + KB_SIG;
+
+        private static final String SD_JWT_IAT_MISSING =
+                CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
+                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\"}") + "." + KB_SIG;
+
+        private static final String SD_JWT_IAT_IN_FUTURE =
+                CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
+                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\",\"iat\":" + (NOW_SEC + 120) + "}") + "." + KB_SIG;
+
+        private static final String SD_JWT_NO_KB =
+                CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~";
+
+        private AuthorizationRequestResponseDto buildAuthRequest() {
+            DCQLQueryDto dcql = new DCQLQueryDto(
+                    List.of(new CredentialQueryDto(
+                            "cred1", "dc+sd-jwt",
+                            new CredentialMetaDto(List.of("cred1"), null),
+                            true, false, null, null)),
+                    null);
+            return new AuthorizationRequestResponseDto(EXPECTED_CLIENT_ID, dcql, null, EXPECTED_NONCE, "responseUri", false, false);
+        }
+
+        private Map<String, List<String>> tokens(String sdJwt) {
+            Map<String, List<String>> map = new HashMap<>();
+            map.put("cred1", List.of(sdJwt));
+            return map;
+        }
+
+        @Test
+        void shouldReturnNull_whenKbJwtIatIsValid() {
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtKbJwtIat(buildAuthRequest(), tokens(SD_JWT_VALID_IAT));
+            assertNull(result);
+        }
+
+        @Test
+        void shouldReturnNull_whenSdJwtTokensMapIsEmpty() {
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtKbJwtIat(buildAuthRequest(), new HashMap<>());
+            assertNull(result);
+        }
+
+        @Test
+        void shouldReturnIatMissingOrInvalid_whenKbJwtIatAbsent() {
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtKbJwtIat(buildAuthRequest(), tokens(SD_JWT_IAT_MISSING));
+            assertEquals(ErrorCode.KB_JWT_IAT_MISSING_OR_INVALID, result);
+        }
+
+        @Test
+        void shouldReturnIatMissingOrInvalid_whenKbJwtAbsent() {
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtKbJwtIat(buildAuthRequest(), tokens(SD_JWT_NO_KB));
+            assertEquals(ErrorCode.KB_JWT_IAT_MISSING_OR_INVALID, result);
+        }
+
+        @Test
+        void shouldReturnIatInFuture_whenKbJwtIatIsInFuture() {
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtKbJwtIat(buildAuthRequest(), tokens(SD_JWT_IAT_IN_FUTURE));
+            assertEquals(ErrorCode.KB_JWT_IAT_IN_FUTURE, result);
+        }
+
+        @Test
+        void shouldReturnNull_whenHolderBindingNotRequired() {
+            DCQLQueryDto dcql = new DCQLQueryDto(
+                    List.of(new CredentialQueryDto(
+                            "cred1", "dc+sd-jwt",
+                            new CredentialMetaDto(List.of("cred1"), null),
+                            false, false, null, null)),
+                    null);
+            AuthorizationRequestResponseDto authRequest = new AuthorizationRequestResponseDto(
+                    EXPECTED_CLIENT_ID, dcql, null, EXPECTED_NONCE, "responseUri", false, false);
+
+            // iat is not checked when holder binding is not required
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtKbJwtIat(authRequest, tokens(SD_JWT_IAT_MISSING));
             assertNull(result);
         }
     }

--- a/verify-service/src/test/java/io/inji/verify/utils/SecurityUtilsTest.java
+++ b/verify-service/src/test/java/io/inji/verify/utils/SecurityUtilsTest.java
@@ -15,7 +15,7 @@ class SecurityUtilsTest {
     void testGenerateNonce_LengthAndFormat() {
         String nonce = SecurityUtils.generateNonce();
 
-        assertEquals(22, nonce.length());
+        assertEquals(32, nonce.length()); // 24 bytes → 32 base64url chars (no padding)
 
         // Base64URL without padding: [A-Za-z0-9\-_], no '=' padding
         assertTrue(Pattern.matches("^[A-Za-z0-9\\-_]+$", nonce));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter validation for certain presentation tokens, including checking an additional timestamp claim when required.
  * Increased nonce length for stronger request security.

* **Bug Fixes**
  * Requests with missing, invalid, or future-dated token timestamps now return clearer validation errors.
  * Submission flow now rejects invalid token payloads earlier with a bad request response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->