### PR TITLE
#2013 added validation to check `iat` in KB-JWT is not too old; also fixed nginx conf issue

### DIFF
--- a/docs/stoplight_docs/api-documentation-openapi-draft23.yaml
+++ b/docs/stoplight_docs/api-documentation-openapi-draft23.yaml
@@ -1114,12 +1114,12 @@ paths:
           description: Invalid request payload
         '500':
           description: Internal server error
-  /well-known/did.json:
+  /did.json:
     get:
       summary: Get the DID document
       description: |-
         ## Description
-        This endpoint is part of a standard DID discovery mechanism, following the .well-known pattern. It is used to retrieve a DID (Decentralized Identifier) document for a given DID. A DID document contains crucial information for interacting with a DID, including public keys for authentication and service endpoints. This is introduced in version *0.14.x*.
+        This endpoint is used to retrieve a DID (Decentralized Identifier) document for a given DID. A DID document contains crucial information for interacting with a DID, including public keys for authentication and service endpoints. This is introduced in version *0.14.x*.
       tags:
         - VP Request
       responses:

--- a/docs/stoplight_docs/api-documentation-openapi.yaml
+++ b/docs/stoplight_docs/api-documentation-openapi.yaml
@@ -1135,12 +1135,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalErrorResponse'
-  /well-known/did.json:
+  /did.json:
     get:
       summary: Get the DID document
       description: |-
         ## Description
-        Retrieves the DID (Decentralized Identifier) document for the verifier, following the `.well-known` discovery pattern.
+        Retrieves the DID (Decentralized Identifier) document for the verifier.
         The DID document contains public keys for authentication and service endpoints. Supports Authorization Requests by reference with DID-based `client_id` (using the `decentralized_identifier:` prefix per OpenID4VP v1.0).
       tags:
         - VP Request

--- a/helm/inji-verify-ui/templates/nginx-configmap.yaml
+++ b/helm/inji-verify-ui/templates/nginx-configmap.yaml
@@ -43,16 +43,6 @@ data:
           proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header   X-Forwarded-Host $server_name;
         }
-        location /.well-known/did.json {
-          proxy_pass http://{{ .Values.inji_verify_service.host }}/v1/verify/.well-known/did.json;
-          proxy_redirect     off;
-          proxy_set_header   Host $host;
-          proxy_set_header   X-Real-IP $remote_addr;
-          proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header   X-Forwarded-Host $server_name;
-          proxy_set_header   Connection close;
-        }
-  
         location / {
           try_files $uri $uri/ /index.html;
         }

--- a/verify-service/src/main/java/io/inji/verify/enums/ErrorCode.java
+++ b/verify-service/src/main/java/io/inji/verify/enums/ErrorCode.java
@@ -88,7 +88,8 @@ public enum ErrorCode {
     VP_TOKEN_CLAIM_VALUE_MISMATCH("invalid_request", "vp_token ldp_vc credential claim value does not match any of the declared values in the DCQL query."),
     VP_TOKEN_CLAIM_SETS_NOT_SATISFIED("invalid_request", "vp_token credential does not satisfy any of the claim_sets options declared in the DCQL query."),
     KB_JWT_IAT_MISSING_OR_INVALID("invalid_request", "KB-JWT iat claim is missing or invalid."),
-    KB_JWT_IAT_IN_FUTURE("invalid_request", "KB-JWT iat is in the future beyond the allowed clock skew.");
+    KB_JWT_IAT_IN_FUTURE("invalid_request", "KB-JWT iat is in the future beyond the allowed clock skew."),
+    KB_JWT_IAT_TOO_OLD("invalid_request", "KB-JWT iat is too far in the past beyond the allowed max age.");
 
     private final String errorCode;
     private final String errorMessage;

--- a/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImpl.java
+++ b/verify-service/src/main/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImpl.java
@@ -80,6 +80,9 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
     @Value("${inji.verify.redirect-uri}")
     String redirectUri;
 
+    @Value("${inji.verify.kb-jwt-max-age-seconds:#{600}}")
+    long kbJwtMaxAgeSeconds;
+
     final AuthorizationRequestCreateResponseRepository authorizationRequestCreateResponseRepository;
     final VPSubmissionRepository vpSubmissionRepository;
     final CredentialsVerifier credentialsVerifier;
@@ -315,9 +318,15 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
 
     /**
      * Validates the KB-JWT {@code iat} claim for all SD-JWT tokens in a single pass.
-     * Checks that {@code iat} is present and not in the future beyond clock skew.
-     * No max-age check — per SD-JWT RFC 9901, {@code nonce} is the replay-protection
-     * mechanism; {@code iat} only needs to be a valid past/present timestamp.
+     * Checks that {@code iat} is:
+     * <ul>
+     *   <li>present and a positive value</li>
+     *   <li>not in the future beyond {@code clockSkewSeconds} (60 s)</li>
+     *   <li>not older than {@code kbJwtMaxAgeSeconds} (default: 600 s / 10 minutes)</li>
+     * </ul>
+     * The {@code nonce} is the primary replay-protection mechanism per SD-JWT RFC 9901;
+     * {@code kbJwtMaxAgeSeconds} guards against very stale KB-JWTs (e.g. replayed presentations).
+     * Configurable via {@code inji.verify.kb-jwt-max-age-seconds} (default: 600 s / 10 minutes).
      * Only applies to query IDs where {@code require_cryptographic_holder_binding=true}.
      * Returns the first {@link ErrorCode} encountered, or null if all tokens pass.
      */
@@ -345,6 +354,10 @@ public class VerifiablePresentationSubmissionServiceImpl implements VerifiablePr
                 if (iat > nowSeconds + clockSkewSeconds) {
                     log.error("KB-JWT iat is in the future for query ID: {}, iat={}, now={}", queryId, iat, nowSeconds);
                     return ErrorCode.KB_JWT_IAT_IN_FUTURE;
+                }
+                if (iat < nowSeconds - kbJwtMaxAgeSeconds) {
+                    log.error("KB-JWT iat is too old for query ID: {}, iat={}, now={}, maxAge={}s", queryId, iat, nowSeconds, kbJwtMaxAgeSeconds);
+                    return ErrorCode.KB_JWT_IAT_TOO_OLD;
                 }
             }
         }

--- a/verify-service/src/main/resources/application-local.properties
+++ b/verify-service/src/main/resources/application-local.properties
@@ -39,3 +39,7 @@ inji.verify.redirect-uri=${INJI_VERIFY_REDIRECT_URI:https://injiverify.dev.mosip
 inji.verify.response-code-expiry-time-in-mins=${INJI_VERIFY_RESPONSE_CODE_EXPIRY_TIME_IN_MINS:5}
 
 inji.verify.claims-with-meta-data=${INJI_VERIFY_CLAIMS_WITH_META_DATA:_sd,_sd_alg,iss,cnf,sub,aud,exp,nbf,iat,cti}
+
+# Maximum age (in seconds) allowed for a KB-JWT iat claim. KB-JWTs older than this are rejected at direct-post.
+# Configurable via env INJI_KB_JWT_MAX_AGE_SECONDS. Default: 600 s (10 minutes).
+inji.verify.kb-jwt-max-age-seconds=${INJI_KB_JWT_MAX_AGE_SECONDS:600}

--- a/verify-service/src/main/resources/application.properties
+++ b/verify-service/src/main/resources/application.properties
@@ -35,3 +35,7 @@ inji.verify.redirect-uri=${INJI_VERIFY_REDIRECT_URI:https://injiverify.dev.mosip
 inji.verify.response-code-expiry-time-in-mins=${INJI_VERIFY_RESPONSE_CODE_EXPIRY_TIME_IN_MINS:5}
 
 inji.verify.claims-with-meta-data=${INJI_VERIFY_CLAIMS_WITH_META_DATA:_sd,_sd_alg,iss,cnf,sub,aud,exp,nbf,iat,cti}
+
+# Maximum age (in seconds) allowed for a KB-JWT iat claim. KB-JWTs older than this are rejected at direct-post.
+# Configurable via env INJI_KB_JWT_MAX_AGE_SECONDS. Default: 600 s (10 minutes).
+inji.verify.kb-jwt-max-age-seconds=${INJI_KB_JWT_MAX_AGE_SECONDS:600}

--- a/verify-service/src/test/java/io/inji/verify/controller/VPSubmissionControllerTest.java
+++ b/verify-service/src/test/java/io/inji/verify/controller/VPSubmissionControllerTest.java
@@ -617,6 +617,22 @@ class VPSubmissionControllerTest {
         assertEquals(ErrorCode.KB_JWT_IAT_IN_FUTURE.getErrorCode(), body.getErrorCode());
     }
 
+    @Test
+    void shouldReturnBadRequest_whenSdJwtKbJwtIatTooOld() {
+        mockActiveAuth();
+
+        when(vpSubmissionService.processSdJwtClientIdAndNonce(any(), any())).thenReturn(null);
+        when(vpSubmissionService.processSdJwtKbJwtIat(any(), any()))
+                .thenReturn(ErrorCode.KB_JWT_IAT_TOO_OLD);
+
+        ResponseEntity<?> response = controller.submitVP(VALID_VP_TOKEN, STATE, null, null, request);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        ErrorDto body = (ErrorDto) response.getBody();
+        assertNotNull(body);
+        assertEquals(ErrorCode.KB_JWT_IAT_TOO_OLD.getErrorCode(), body.getErrorCode());
+    }
+
     // ---- validateRequest missing paths ----
 
     @Test

--- a/verify-service/src/test/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImplTest.java
+++ b/verify-service/src/test/java/io/inji/verify/services/impl/VerifiablePresentationSubmissionServiceImplTest.java
@@ -2468,6 +2468,11 @@ public class VerifiablePresentationSubmissionServiceImplTest {
                 CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
                 + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\",\"iat\":" + (NOW_SEC + 120) + "}") + "." + KB_SIG;
 
+        // iat = 1 year in the past (exceeds 600 s / 10 min default max-age)
+        private static final String SD_JWT_IAT_TOO_OLD =
+                CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~"
+                + KB_HEADER + "." + b64("{\"nonce\":\"" + EXPECTED_NONCE + "\",\"aud\":\"" + EXPECTED_CLIENT_ID + "\",\"iat\":" + (NOW_SEC - 31536000) + "}") + "." + KB_SIG;
+
         private static final String SD_JWT_NO_KB =
                 CRED_HEADER + "." + CRED_PAYLOAD + "." + CRED_SIG + "~";
 
@@ -2520,6 +2525,13 @@ public class VerifiablePresentationSubmissionServiceImplTest {
             ErrorCode result = verifiablePresentationSubmissionService
                     .processSdJwtKbJwtIat(buildAuthRequest(), tokens(SD_JWT_IAT_IN_FUTURE));
             assertEquals(ErrorCode.KB_JWT_IAT_IN_FUTURE, result);
+        }
+
+        @Test
+        void shouldReturnIatTooOld_whenKbJwtIatExceedsMaxAge() {
+            ErrorCode result = verifiablePresentationSubmissionService
+                    .processSdJwtKbJwtIat(buildAuthRequest(), tokens(SD_JWT_IAT_TOO_OLD));
+            assertEquals(ErrorCode.KB_JWT_IAT_TOO_OLD, result);
         }
 
         @Test

--- a/verify-ui/nginx.conf
+++ b/verify-ui/nginx.conf
@@ -18,16 +18,6 @@ server {
         proxy_set_header   Connection close;
     }
 
-    location /.well-known/did.json {
-            proxy_pass http://verify-service:8080/v1/verify/.well-known/did.json;
-            proxy_redirect     off;
-            proxy_set_header   Host $host;
-            proxy_set_header   X-Real-IP $remote_addr;
-            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header   X-Forwarded-Host $server_name;
-            proxy_set_header   Connection close;
-        }
-
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The DID document endpoint is now available at `/did.json` instead of `/.well-known/did.json`.
  * Added a configurable maximum age check for KB-JWT `iat` values, with a default of 600 seconds.

* **Bug Fixes**
  * Requests with KB-JWT `iat` values that are too old are now rejected with a clear error.
  * Updated routing so the old `/.well-known/did.json` path is no longer explicitly served.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->