### PR TITLE
[INJIVER-2095] fix: footer cropping the error message on offline page

### DIFF
--- a/verify-ui/src/__tests__/components/Home/VerificationProgressTracker/Copyrights.spec.tsx
+++ b/verify-ui/src/__tests__/components/Home/VerificationProgressTracker/Copyrights.spec.tsx
@@ -1,13 +1,40 @@
 import React from "react";
 import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import Copyrights from "../../../../components/PageTemplate/Copyrights";
+import { Pages } from "../../../../utils/config";
 
 describe("Copyrights", () => {
   test("renders copyrights content element", () => {
-    const { container } = render(<Copyrights />);
+    const { container } = render(
+      <MemoryRouter>
+        <Copyrights />
+      </MemoryRouter>
+    );
 
     expect(
       container.querySelector("#copyrights-content")
     ).toBeInTheDocument();
+  });
+
+  test("uses fixed positioning on non-offline pages", () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={[Pages.Home]}>
+        <Copyrights />
+      </MemoryRouter>
+    );
+
+    expect(container.firstChild).toHaveClass("fixed", "bottom-0");
+  });
+
+  test("uses normal document flow on offline page", () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={[Pages.Offline]}>
+        <Copyrights />
+      </MemoryRouter>
+    );
+
+    expect(container.firstChild).not.toHaveClass("fixed");
+    expect(container.firstChild).not.toHaveClass("bottom-0");
   });
 });

--- a/verify-ui/src/components/PageTemplate/Copyrights.tsx
+++ b/verify-ui/src/components/PageTemplate/Copyrights.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
 import { Pages } from "../../utils/config";
 
-function Copyrights(props: any) {
+function Copyrights() {
     const {t} = useTranslation("CopyRight");
     const { pathname } = useLocation();
     const isOfflinePage = pathname === Pages.Offline;

--- a/verify-ui/src/components/PageTemplate/Copyrights.tsx
+++ b/verify-ui/src/components/PageTemplate/Copyrights.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router-dom";
+import { Pages } from "../../utils/config";
 
 function Copyrights(props: any) {
     const {t} = useTranslation("CopyRight");
+    const { pathname } = useLocation();
+    const isOfflinePage = pathname === Pages.Offline;
 
     return (
-        <div className="fixed grid bottom-0 w-[100vw] lg:w-[49vw] content-center justify-center bg-white">
+        <div className={`grid w-[100vw] lg:w-[49vw] content-center justify-center bg-white ${isOfflinePage ? "" : "fixed bottom-0"}`}>
             <div className="xs:w-[90vw] lg:w-[40vw] mx-auto border-b-[1px] border-b-copyRightsBorder opacity-20"/>
             <p id="copyrights-content" className="py-4 px-0 w-[100%] text-center text-normalTextSize font-normal text-copyRightsText">
                 {t('content')}


### PR DESCRIPTION
<img width="947" height="412" alt="image" src="https://github.com/user-attachments/assets/6b948ae6-b7e2-4532-811b-5c220a7fefb0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copyright placement across pages.
  * Copyright information remains fixed to the bottom of the screen on standard pages and now flows naturally within the offline page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->