### PR TITLE
#2119 Remove unused `com.auth0` `java-jwt` to clear revoked signing-key finding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,6 @@
         <vcverifier-jar.version>1.9.0-SNAPSHOT</vcverifier-jar.version>
         <json.version>20240303</json.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
-        <java-jwt.version>4.5.2</java-jwt.version>
         <jandex.version>3.6.0</jandex.version>
         <titanium-json-ld.version>1.7.0</titanium-json-ld.version>
         <tink.version>1.16.0</tink.version>

--- a/verify-service/pom.xml
+++ b/verify-service/pom.xml
@@ -129,11 +129,6 @@
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.auth0</groupId>
-            <artifactId>java-jwt</artifactId>
-            <version>${java-jwt.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.crypto.tink</groupId>
             <artifactId>tink</artifactId>
             <version>${tink.version}</version>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the unused authentication library dependency and its associated build configuration.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->