### PR TITLE
[INJIVER-2147] fix: show error alerts in red

### DIFF
--- a/verify-ui/src/components/Home/VerificationSection/Result/index.tsx
+++ b/verify-ui/src/components/Home/VerificationSection/Result/index.tsx
@@ -52,7 +52,7 @@ const Result = () => {
 
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          dispatch(raiseAlert({ message, type: "error" }));
+          dispatch(raiseAlert({ message, severity: "error", open: true }));
 
         }
       } else if (typeof vc === "string") {
@@ -62,7 +62,7 @@ const Result = () => {
           setCredentialType(claims.regularClaims.vct);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          dispatch(raiseAlert({ message, type: "error" }));
+          dispatch(raiseAlert({ message, severity: "error", open: true }));
         }
       } else {
         setClaims(vc as LdpVc);


### PR DESCRIPTION
The alert was raised with the wrong field name, so it never got an error severity and fell back to success green.
The alerts slice only reads severity, and AlertMessage defaults missing severity to "success" (bg-successAlert).

Fix: Use severity: "error" (and open: true) in both catch paths so the toast renders red.

<img width="950" height="414" alt="Screenshot 2026-07-21 170708" src="https://github.com/user-attachments/assets/d4f53d56-674c-44e8-a777-978418753850" />
