### PR TITLE
INJIVER-1062: Hide credential details for invalid QR

### DIFF
--- a/verify-ui/src/__tests__/components/Home/VerificationSection/Result/index.spec.tsx
+++ b/verify-ui/src/__tests__/components/Home/VerificationSection/Result/index.spec.tsx
@@ -106,5 +106,7 @@ describe("Vc Result", () => {
     const message = container.querySelector("#vc-result-display-message");
     expect(message).toBeInTheDocument();
     expect(message?.textContent).toBeTruthy();
+    expect(container.querySelector('[data-testid="vc-detail-view-mock"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="vc-detail-modal-mock"]')).not.toBeInTheDocument();
   });
 });

--- a/verify-ui/src/components/Home/VerificationSection/Result/index.tsx
+++ b/verify-ui/src/components/Home/VerificationSection/Result/index.tsx
@@ -39,6 +39,13 @@ const Result = () => {
 
   useEffect(() => {
     const fetchDecodedClaims = async () => {
+      if (vcStatus !== "SUCCESS") {
+        setClaims(null);
+        setCredentialType("");
+        setModalOpen(false);
+        return;
+      }
+
       if (isCWT(vc)) {
         try {
           const cwtHex =
@@ -75,7 +82,9 @@ const Result = () => {
       }
     };
     fetchDecodedClaims();
-  }, [dispatch, vc]);
+  }, [dispatch, vc, vcStatus]);
+
+  const shouldShowCredentialDetails = vcStatus === "SUCCESS" && claims !== null;
 
   const clearTimer = () => {
     if (timerRef.current) {
@@ -100,7 +109,7 @@ const Result = () => {
       </div>
       <div>
         <div className={`h-[3px] border-b-2 border-b-transparent`} />
-        {claims && (
+        {shouldShowCredentialDetails && (
           <DisplayVcDetailView
             vc={claims}
             onExpand={() => setModalOpen(true)}
@@ -115,7 +124,7 @@ const Result = () => {
           />
         </div>
       </div>
-      {claims && (
+      {shouldShowCredentialDetails && (
         <DisplayVcDetailsModal
           isOpen={isModalOpen}
           onClose={() => setModalOpen(false)}

--- a/verify-ui/src/components/Home/VerificationSection/Result/index.tsx
+++ b/verify-ui/src/components/Home/VerificationSection/Result/index.tsx
@@ -38,11 +38,14 @@ const Result = () => {
   };
 
   useEffect(() => {
+    let active = true;
+
     const fetchDecodedClaims = async () => {
+      setClaims(null);
+      setCredentialType("");
+      setModalOpen(false);
+
       if (vcStatus !== "SUCCESS") {
-        setClaims(null);
-        setCredentialType("");
-        setModalOpen(false);
         return;
       }
 
@@ -55,23 +58,35 @@ const Result = () => {
                 ? uint8ArrayToHex(new Uint8Array(vc))
                 : (vc as string);
           const claims = extractMappedClaim(cwtHex, 169);
-          setClaims(claims as LdpVc);
+          if (active) {
+            setClaims(claims as LdpVc);
+          }
 
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          dispatch(raiseAlert({ message, severity: "error", open: true }));
+          if (active) {
+            dispatch(raiseAlert({ message, severity: "error", open: true }));
+          }
 
         }
       } else if (typeof vc === "string") {
         try {
           const claims = await decodeSdJwtToken(vc);
-          setClaims(claims as SdJwtVc);
-          setCredentialType(claims.regularClaims.vct);
+          if (active) {
+            setClaims(claims as SdJwtVc);
+            setCredentialType(claims.regularClaims.vct);
+          }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          dispatch(raiseAlert({ message, severity: "error", open: true }));
+          if (active) {
+            dispatch(raiseAlert({ message, severity: "error", open: true }));
+          }
         }
       } else {
+        if (!active || !vc) {
+          return;
+        }
+
         setClaims(vc as LdpVc);
         const typeEntry = vc.type[1];
         if (typeof typeEntry === "string") {
@@ -81,7 +96,12 @@ const Result = () => {
         }
       }
     };
-    fetchDecodedClaims();
+
+    void fetchDecodedClaims();
+
+    return () => {
+      active = false;
+    };
   }, [dispatch, vc, vcStatus]);
 
   const shouldShowCredentialDetails = vcStatus === "SUCCESS" && claims !== null;


### PR DESCRIPTION
## Description

Fixes INJIVER-1062.

When an invalid QR code is uploaded, Inji Verify now displays only the invalid credential message. Credential details and the details popup are hidden.

## Changes

- Clear credential data when verification is not successful.
- Render credential details only when verification status is `SUCCESS`.
- Added test coverage to ensure invalid results do not display credential details.

## Testing

Tested locally using an invalid QR code.

Confirmed that the invalid credential message is displayed and no credential details are visible.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Credential details and detail modals are now shown only after successful verification.
  * Failed or incomplete verification results no longer display stale credential claims or credential types.
  * Credential information is refreshed correctly when verification status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->