### PR TITLE
#2217 fixed bug - credential_sets in dcqlQuery is dropped when building VP request (Verify UI)

### DIFF
--- a/verify-ui/src/__tests__/redux/features/verify/vpVerificationState.spec.ts
+++ b/verify-ui/src/__tests__/redux/features/verify/vpVerificationState.spec.ts
@@ -56,6 +56,78 @@ describe("vpVerification slice", () => {
         expect(state.sharingType).toBe(VCShareType.SINGLE);
     });
 
+    test("should merge credential_sets from selected credentials into dcqlQuery", () => {
+        const credentialSets = [
+            {
+                options: [["mosip_verifiable_credential_id"], ["life_insurance_credential_id"]],
+            },
+        ];
+
+        const selectedCredentials = [
+            {
+                id: "1",
+                type: "Type1",
+                essential: true,
+                dcqlQuery: {
+                    credentials: [{ id: "mosip_verifiable_credential_id", format: "ldp_vc", meta: {} }],
+                    credential_sets: credentialSets,
+                },
+            },
+            {
+                id: "2",
+                type: "Type2",
+                essential: false,
+                dcqlQuery: {
+                    credentials: [{ id: "life_insurance_credential_id", format: "ldp_vc", meta: {} }],
+                },
+            },
+        ] as any;
+
+        const initialState = {
+            ...vpVerificationReducer(undefined, { type: "@@INIT" }),
+            selectedCredentials: [],
+            originalSelectedCredentials: [],
+            unVerifiedCredentials: [],
+            dcqlQuery: mockDcqlQuery,
+        } as any;
+
+        const state = vpVerificationReducer(
+            initialState,
+            setSelectedCredentials({ selectedCredentials })
+        );
+
+        expect(state.dcqlQuery.credentials).toHaveLength(2);
+        expect(state.dcqlQuery.credential_sets).toEqual(credentialSets);
+    });
+
+    test("should omit credential_sets from dcqlQuery when none of the selected credentials define it", () => {
+        const selectedCredentials = [
+            {
+                id: "2",
+                type: "Type2",
+                essential: false,
+                dcqlQuery: {
+                    credentials: [{ id: "desc2", format: "dc+sd-jwt", meta: {} }],
+                },
+            },
+        ] as any;
+
+        const initialState = {
+            ...vpVerificationReducer(undefined, { type: "@@INIT" }),
+            selectedCredentials: [],
+            originalSelectedCredentials: [],
+            unVerifiedCredentials: [],
+            dcqlQuery: mockDcqlQuery,
+        } as any;
+
+        const state = vpVerificationReducer(
+            initialState,
+            setSelectedCredentials({ selectedCredentials })
+        );
+
+        expect(state.dcqlQuery.credential_sets).toBeUndefined();
+    });
+
     test("should handle setSelectCredential with SelectWalletPanel open", () => {
         (getVerifiableClaims as jest.Mock).mockReturnValue([
             {

--- a/verify-ui/src/__tests__/redux/features/verify/vpVerificationState.spec.ts
+++ b/verify-ui/src/__tests__/redux/features/verify/vpVerificationState.spec.ts
@@ -57,9 +57,14 @@ describe("vpVerification slice", () => {
     });
 
     test("should merge credential_sets from selected credentials into dcqlQuery", () => {
-        const credentialSets = [
+        const firstCredentialSets = [
             {
                 options: [["mosip_verifiable_credential_id"], ["life_insurance_credential_id"]],
+            },
+        ];
+        const secondCredentialSets = [
+            {
+                options: [["health_insurance_credential_id"]],
             },
         ];
 
@@ -70,7 +75,7 @@ describe("vpVerification slice", () => {
                 essential: true,
                 dcqlQuery: {
                     credentials: [{ id: "mosip_verifiable_credential_id", format: "ldp_vc", meta: {} }],
-                    credential_sets: credentialSets,
+                    credential_sets: firstCredentialSets,
                 },
             },
             {
@@ -79,6 +84,7 @@ describe("vpVerification slice", () => {
                 essential: false,
                 dcqlQuery: {
                     credentials: [{ id: "life_insurance_credential_id", format: "ldp_vc", meta: {} }],
+                    credential_sets: secondCredentialSets,
                 },
             },
         ] as any;
@@ -97,7 +103,10 @@ describe("vpVerification slice", () => {
         );
 
         expect(state.dcqlQuery.credentials).toHaveLength(2);
-        expect(state.dcqlQuery.credential_sets).toEqual(credentialSets);
+        expect(state.dcqlQuery.credential_sets).toEqual([
+            ...firstCredentialSets,
+            ...secondCredentialSets,
+        ]);
     });
 
     test("should omit credential_sets from dcqlQuery when none of the selected credentials define it", () => {
@@ -125,7 +134,7 @@ describe("vpVerification slice", () => {
             setSelectedCredentials({ selectedCredentials })
         );
 
-        expect(state.dcqlQuery.credential_sets).toBeUndefined();
+        expect(state.dcqlQuery).not.toHaveProperty("credential_sets");
     });
 
     test("should handle setSelectCredential with SelectWalletPanel open", () => {

--- a/verify-ui/src/redux/features/verify/vpVerificationState.ts
+++ b/verify-ui/src/redux/features/verify/vpVerificationState.ts
@@ -8,9 +8,15 @@ export const OVP_SESSION_SELECTED_CREDENTIALS_KEY = "ovp_selectedCredentials";
 const DEFAULT_CREDENTIALS = (): claim[] =>
   getVerifiableClaims()?.filter((c) => c.essential) ?? [];
 
-const mergeDcqlFromCredentials = (credentials: claim[]): DcqlQuery => ({
-  credentials: credentials.flatMap((c) => c.dcqlQuery?.credentials ?? []),
-});
+const mergeDcqlFromCredentials = (credentials: claim[]): DcqlQuery => {
+  const credentialSets = credentials.flatMap(
+    (c) => c.dcqlQuery?.credential_sets ?? []
+  );
+  return {
+    credentials: credentials.flatMap((c) => c.dcqlQuery?.credentials ?? []),
+    ...(credentialSets.length > 0 ? { credential_sets: credentialSets } : {}),
+  };
+};
 
 const hasValidCredentialStructure = (item: unknown): item is claim => {
   if (!item || typeof item !== "object") return false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential selection handling so nested credential sets are correctly included in verification requests.
  * Prevented empty credential set data from being added when no sets are selected.

* **Tests**
  * Added coverage for credential set merging and omission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->